### PR TITLE
fix: use per-commit diff instead of full-PR diff for change detection

### DIFF
--- a/.changeset/per-commit-diff-detection.md
+++ b/.changeset/per-commit-diff-detection.md
@@ -1,0 +1,5 @@
+---
+'my-package': patch
+---
+
+Use per-commit diff instead of full-PR diff for CI change detection

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,6 @@ jobs:
 
       - name: Detect changes
         id: changes
-        env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/detect-code-changes.mjs
 
   # === FAST CHECKS - run before slow tests for fastest feedback ===

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-14T10:38:04.631Z for PR creation at branch issue-31-5adf4dcddf53 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/31

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-14T10:38:04.631Z for PR creation at branch issue-31-5adf4dcddf53 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/31

--- a/docs/case-studies/issue-31/README.md
+++ b/docs/case-studies/issue-31/README.md
@@ -1,0 +1,97 @@
+# Case Study: Per-commit diff for change detection
+
+**Issue:** [#31](https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/31)
+**Source:** [link-assistant/web-capture#50](https://github.com/link-assistant/web-capture/issues/50), [link-assistant/web-capture#51](https://github.com/link-assistant/web-capture/pull/51)
+
+## Problem Statement
+
+The `scripts/detect-code-changes.mjs` script compared `GITHUB_BASE_SHA` to `GITHUB_HEAD_SHA` for pull request events. This returns **all files changed across the entire PR**, not just what the latest push changed. A commit that only modifies non-code files (e.g., `.gitkeep`, `README.md`) still triggers all CI jobs if any earlier commit in the same PR touched code files.
+
+## Root Cause
+
+Two separate mechanisms cause full-PR diffs instead of per-commit diffs:
+
+### 1. `GITHUB_BASE_SHA...GITHUB_HEAD_SHA` comparison
+
+The original script used environment variables to compare the PR base against the PR head:
+
+```javascript
+const output = exec(`git diff --name-only ${baseSha} ${headSha}`);
+```
+
+This gives the same result as GitHub Actions `paths:` filters — the full PR diff.
+
+### 2. GitHub Actions synthetic merge commit
+
+GitHub Actions creates a **synthetic merge commit** for `pull_request` events:
+
+- `HEAD` = synthetic merge commit (not the actual PR head)
+- `HEAD^` = base branch (first parent)
+- `HEAD^2` = actual PR head commit (second parent)
+
+Even `git diff HEAD^ HEAD` gives the full PR diff, because `HEAD^` is the base branch.
+
+### Evidence
+
+In [link-assistant/web-capture PR #49](https://github.com/link-assistant/web-capture/pull/49), commit `0e9b6e8c` only modified `.gitkeep` but triggered all 8 CI jobs (lint, test on 3 OSes, build, changeset check) because the PR as a whole contained code changes.
+
+## Timeline
+
+1. PR #49 in web-capture opened with commits touching `js/` and `rust/` code
+2. Commit `0e9b6e8c` pushed — only modifies `.gitkeep` at repo root
+3. Full CI suite triggered because diff evaluates all PR files, not just the latest push
+4. [web-capture#50](https://github.com/link-assistant/web-capture/issues/50) filed requesting fix
+5. [web-capture#51](https://github.com/link-assistant/web-capture/pull/51) implements fix with per-commit diff via merge commit detection
+6. [This issue (#31)](https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/31) filed to port the fix to this template repo
+
+## Solution
+
+### Per-commit diff via merge commit detection
+
+The script now detects GitHub Actions' synthetic merge commit and uses the correct diff range:
+
+```javascript
+function isMergeCommit() {
+  const parentCount = exec('git cat-file -p HEAD')
+    .split('\n')
+    .filter((line) => line.startsWith('parent ')).length;
+  return parentCount > 1;
+}
+```
+
+For merge commits (PR events): `git diff HEAD^2^ HEAD^2` — the per-commit diff of the actual PR head commit.
+
+For push events (non-merge): `git diff HEAD^ HEAD` — regular per-commit diff.
+
+### Fallback handling
+
+- If `HEAD^2^` doesn't exist (first commit in PR), falls back to `git diff HEAD^ HEAD^2` (full diff against base)
+- If `HEAD^` doesn't exist (first commit ever), falls back to `git ls-tree --name-only -r HEAD`
+
+### Environment variable cleanup
+
+The `GITHUB_BASE_SHA` and `GITHUB_HEAD_SHA` environment variables were removed from the workflow since the script no longer uses them — merge commit detection via `git cat-file` is self-contained.
+
+## Files Changed
+
+| File                                  | Change                                                               |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| `scripts/detect-code-changes.mjs`     | Replace full-PR diff with per-commit diff via merge commit detection |
+| `.github/workflows/release.yml`       | Remove unused `GITHUB_BASE_SHA`/`GITHUB_HEAD_SHA` env vars           |
+| `experiments/test-detect-changes.mjs` | 17 edge-case tests for change classification logic                   |
+
+## Verification
+
+With this fix, if a commit only modifies `.gitkeep`:
+
+- `detect-changes` job runs (lightweight, ~5s)
+- Merge commit detected, per-commit diff used (`HEAD^2^..HEAD^2`)
+- All outputs are `false` (only `.gitkeep` changed)
+- All downstream jobs (lint, test, changeset check) are **skipped**
+- CI minutes saved: ~15-30 minutes per non-code commit
+
+## References
+
+- [web-capture PR #51](https://github.com/link-assistant/web-capture/pull/51) — original implementation with CI verification
+- [web-capture issue #50](https://github.com/link-assistant/web-capture/issues/50) — original bug report with evidence
+- [rust-ai-driven-development-pipeline-template#34](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/34) — same bug in Rust template

--- a/docs/case-studies/issue-31/web-capture-pr49-commits.json
+++ b/docs/case-studies/issue-31/web-capture-pr49-commits.json
@@ -1,24 +1,95 @@
-{"message":"Initial commit with task details","sha":"ca470f2"}
-{"message":"feat(js): extract base64 images to files by default, remove --enhanced flag","sha":"88ec580"}
-{"message":"feat(rust): extract base64 images to files by default, remove --enhanced flag","sha":"12f540c"}
-{"message":"test: add image extraction tests for JS and Rust, fix formatting","sha":"756451b"}
-{"message":"chore: add changeset for minor release and bump Rust version to 0.2.0","sha":"a463061"}
-{"message":"style: fix prettier formatting in JS files","sha":"99b5e4e"}
-{"message":"fix: remove unused convertHtmlToMarkdown import and fix changeset formatting","sha":"d30e8ce"}
-{"message":"Revert \"Initial commit with task details\"","sha":"0e9b6e8"}
-{"message":"feat: change default format to markdown, use getenv for env vars in JS","sha":"1c93e90"}
-{"message":"feat: auto-derive output directory from URL when -o is omitted","sha":"1badb1e"}
-{"message":"feat: add --archive flag and --no-extract-images alias","sha":"c1cd4a6"}
-{"message":"feat: use content-hash filenames for extracted images, add SVG test","sha":"c93f8a7"}
-{"message":"docs: update all READMEs with new flags, defaults, and env vars","sha":"7af56d6"}
-{"message":"fix: resolve eslint errors and clippy warnings","sha":"44fa9eb"}
-{"message":"fix: resolve eslint prettier and clippy CI lint failures","sha":"f410edb"}
-{"message":"chore: update Cargo.lock version and web-capture version","sha":"4458ff4"}
-{"message":"fix: wrap long SVG string in extract-images test for prettier","sha":"189a0d6"}
-{"message":"style: format js/README.md markdown tables with prettier","sha":"7928da9"}
-{"message":"feat: add --keep-original-links, API embedImages param, restructure Rust tests","sha":"573a053"}
-{"message":"fix: use case-insensitive extension check in extract_images test","sha":"5263d66"}
-{"message":"style: format README markdown tables with prettier","sha":"7899a21"}
-{"message":"docs: update changeset to include new --keep-original-links and API params","sha":"46c3e54"}
-{"message":"style: fix prettier formatting in extract-images test","sha":"a9e3c86"}
-{"message":"fix: keep original links by default in markdown mode, align API/CLI defaults","sha":"805568e"}
+[
+  { "message": "Initial commit with task details", "sha": "ca470f2" },
+  {
+    "message": "feat(js): extract base64 images to files by default, remove --enhanced flag",
+    "sha": "88ec580"
+  },
+  {
+    "message": "feat(rust): extract base64 images to files by default, remove --enhanced flag",
+    "sha": "12f540c"
+  },
+  {
+    "message": "test: add image extraction tests for JS and Rust, fix formatting",
+    "sha": "756451b"
+  },
+  {
+    "message": "chore: add changeset for minor release and bump Rust version to 0.2.0",
+    "sha": "a463061"
+  },
+  {
+    "message": "style: fix prettier formatting in JS files",
+    "sha": "99b5e4e"
+  },
+  {
+    "message": "fix: remove unused convertHtmlToMarkdown import and fix changeset formatting",
+    "sha": "d30e8ce"
+  },
+  {
+    "message": "Revert \"Initial commit with task details\"",
+    "sha": "0e9b6e8"
+  },
+  {
+    "message": "feat: change default format to markdown, use getenv for env vars in JS",
+    "sha": "1c93e90"
+  },
+  {
+    "message": "feat: auto-derive output directory from URL when -o is omitted",
+    "sha": "1badb1e"
+  },
+  {
+    "message": "feat: add --archive flag and --no-extract-images alias",
+    "sha": "c1cd4a6"
+  },
+  {
+    "message": "feat: use content-hash filenames for extracted images, add SVG test",
+    "sha": "c93f8a7"
+  },
+  {
+    "message": "docs: update all READMEs with new flags, defaults, and env vars",
+    "sha": "7af56d6"
+  },
+  {
+    "message": "fix: resolve eslint errors and clippy warnings",
+    "sha": "44fa9eb"
+  },
+  {
+    "message": "fix: resolve eslint prettier and clippy CI lint failures",
+    "sha": "f410edb"
+  },
+  {
+    "message": "chore: update Cargo.lock version and web-capture version",
+    "sha": "4458ff4"
+  },
+  {
+    "message": "fix: wrap long SVG string in extract-images test for prettier",
+    "sha": "189a0d6"
+  },
+  {
+    "message": "style: format js/README.md markdown tables with prettier",
+    "sha": "7928da9"
+  },
+  {
+    "message": "feat: add --keep-original-links, API embedImages param, restructure Rust tests",
+    "sha": "573a053"
+  },
+  {
+    "message": "fix: use case-insensitive extension check in extract_images test",
+    "sha": "5263d66"
+  },
+  {
+    "message": "style: format README markdown tables with prettier",
+    "sha": "7899a21"
+  },
+  {
+    "message": "docs: update changeset to include new --keep-original-links and API params",
+    "sha": "46c3e54"
+  },
+  {
+    "message": "style: fix prettier formatting in extract-images test",
+    "sha": "a9e3c86"
+  },
+  {
+    "message": "fix: keep original links by default in markdown mode, align API/CLI defaults",
+    "sha": "805568e"
+  }
+]

--- a/docs/case-studies/issue-31/web-capture-pr49-commits.json
+++ b/docs/case-studies/issue-31/web-capture-pr49-commits.json
@@ -1,0 +1,24 @@
+{"message":"Initial commit with task details","sha":"ca470f2"}
+{"message":"feat(js): extract base64 images to files by default, remove --enhanced flag","sha":"88ec580"}
+{"message":"feat(rust): extract base64 images to files by default, remove --enhanced flag","sha":"12f540c"}
+{"message":"test: add image extraction tests for JS and Rust, fix formatting","sha":"756451b"}
+{"message":"chore: add changeset for minor release and bump Rust version to 0.2.0","sha":"a463061"}
+{"message":"style: fix prettier formatting in JS files","sha":"99b5e4e"}
+{"message":"fix: remove unused convertHtmlToMarkdown import and fix changeset formatting","sha":"d30e8ce"}
+{"message":"Revert \"Initial commit with task details\"","sha":"0e9b6e8"}
+{"message":"feat: change default format to markdown, use getenv for env vars in JS","sha":"1c93e90"}
+{"message":"feat: auto-derive output directory from URL when -o is omitted","sha":"1badb1e"}
+{"message":"feat: add --archive flag and --no-extract-images alias","sha":"c1cd4a6"}
+{"message":"feat: use content-hash filenames for extracted images, add SVG test","sha":"c93f8a7"}
+{"message":"docs: update all READMEs with new flags, defaults, and env vars","sha":"7af56d6"}
+{"message":"fix: resolve eslint errors and clippy warnings","sha":"44fa9eb"}
+{"message":"fix: resolve eslint prettier and clippy CI lint failures","sha":"f410edb"}
+{"message":"chore: update Cargo.lock version and web-capture version","sha":"4458ff4"}
+{"message":"fix: wrap long SVG string in extract-images test for prettier","sha":"189a0d6"}
+{"message":"style: format js/README.md markdown tables with prettier","sha":"7928da9"}
+{"message":"feat: add --keep-original-links, API embedImages param, restructure Rust tests","sha":"573a053"}
+{"message":"fix: use case-insensitive extension check in extract_images test","sha":"5263d66"}
+{"message":"style: format README markdown tables with prettier","sha":"7899a21"}
+{"message":"docs: update changeset to include new --keep-original-links and API params","sha":"46c3e54"}
+{"message":"style: fix prettier formatting in extract-images test","sha":"a9e3c86"}
+{"message":"fix: keep original links by default in markdown mode, align API/CLI defaults","sha":"805568e"}

--- a/experiments/test-detect-changes.mjs
+++ b/experiments/test-detect-changes.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+// Test script for detect-code-changes.mjs logic
+// Validates that the change detection correctly classifies files
+
+function isExcludedFromCodeChanges(filePath) {
+  if (filePath.endsWith('.md')) {
+    return true;
+  }
+  const excludedFolders = ['.changeset/', 'docs/', 'experiments/', 'examples/'];
+  for (const folder of excludedFolders) {
+    if (filePath.startsWith(folder)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function classifyFiles(changedFiles) {
+  const mjsChanged = changedFiles.some((f) => f.endsWith('.mjs'));
+  const jsChanged = changedFiles.some((f) => f.endsWith('.js'));
+  const packageChanged = changedFiles.some((f) => f === 'package.json');
+  const docsChanged = changedFiles.some((f) => f.endsWith('.md'));
+  const workflowChanged = changedFiles.some((f) =>
+    f.startsWith('.github/workflows/')
+  );
+
+  const codeChangedFiles = changedFiles.filter(
+    (file) => !isExcludedFromCodeChanges(file)
+  );
+  const codePattern = /\.(mjs|js|json|yml|yaml)$|\.github\/workflows\//;
+  const anyCodeChanged = codeChangedFiles.some((file) =>
+    codePattern.test(file)
+  );
+
+  return {
+    mjsChanged,
+    jsChanged,
+    packageChanged,
+    docsChanged,
+    workflowChanged,
+    anyCodeChanged,
+    codeChangedFiles,
+  };
+}
+
+let passed = 0;
+let failed = 0;
+
+function test(name, files, expected) {
+  const result = classifyFiles(files);
+  const errors = [];
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    if (result[key] !== expectedValue) {
+      errors.push(`  ${key}: expected ${expectedValue}, got ${result[key]}`);
+    }
+  }
+  if (errors.length > 0) {
+    console.log(`FAIL: ${name}`);
+    errors.forEach((e) => console.log(e));
+    failed++;
+  } else {
+    console.log(`PASS: ${name}`);
+    passed++;
+  }
+}
+
+test('.gitkeep only change', ['.gitkeep'], {
+  anyCodeChanged: false,
+  docsChanged: false,
+  mjsChanged: false,
+  jsChanged: false,
+});
+
+test('.gitignore only change', ['.gitignore'], {
+  anyCodeChanged: false,
+});
+
+test('README.md only change', ['README.md'], {
+  anyCodeChanged: false,
+  docsChanged: true,
+});
+
+test('docs/ folder change', ['docs/case-studies/issue-31/README.md'], {
+  anyCodeChanged: false,
+  docsChanged: true,
+});
+
+test('.mjs file change', ['scripts/detect-code-changes.mjs'], {
+  anyCodeChanged: true,
+  mjsChanged: true,
+  jsChanged: false,
+});
+
+test('.js file change', ['src/index.js'], {
+  anyCodeChanged: true,
+  jsChanged: true,
+  mjsChanged: false,
+});
+
+test('package.json change', ['package.json'], {
+  anyCodeChanged: true,
+  packageChanged: true,
+});
+
+test('workflow change', ['.github/workflows/release.yml'], {
+  anyCodeChanged: true,
+  workflowChanged: true,
+});
+
+test(
+  '.changeset/ folder excluded from code changes',
+  ['.changeset/some-change.md'],
+  {
+    anyCodeChanged: false,
+    docsChanged: true,
+  }
+);
+
+test(
+  'experiments/ folder excluded from code changes',
+  ['experiments/test.mjs'],
+  {
+    anyCodeChanged: false,
+  }
+);
+
+test('examples/ folder excluded from code changes', ['examples/demo.js'], {
+  anyCodeChanged: false,
+});
+
+test('LICENSE file', ['LICENSE'], {
+  anyCodeChanged: false,
+  docsChanged: false,
+  mjsChanged: false,
+  jsChanged: false,
+});
+
+test(
+  'Mixed: .gitkeep + .mjs triggers code change',
+  ['.gitkeep', 'scripts/detect-code-changes.mjs'],
+  {
+    anyCodeChanged: true,
+    mjsChanged: true,
+  }
+);
+
+test(
+  'Mixed: README.md + package.json triggers code change',
+  ['README.md', 'package.json'],
+  {
+    anyCodeChanged: true,
+    docsChanged: true,
+    packageChanged: true,
+  }
+);
+
+test('YAML config change', ['eslint.config.js'], {
+  anyCodeChanged: true,
+  jsChanged: true,
+});
+
+test('YAML workflow file', ['.github/workflows/links.yml'], {
+  anyCodeChanged: true,
+  workflowChanged: true,
+});
+
+test('Multiple non-code files', ['.gitkeep', 'LICENSE', '.gitignore'], {
+  anyCodeChanged: false,
+  docsChanged: false,
+  mjsChanged: false,
+  jsChanged: false,
+});
+
+console.log(
+  `\n${passed} passed, ${failed} failed out of ${passed + failed} tests`
+);
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/detect-code-changes.mjs
+++ b/scripts/detect-code-changes.mjs
@@ -1,48 +1,30 @@
 #!/usr/bin/env node
 
-/**
- * Detect code changes for CI/CD pipeline
- *
- * This script detects what types of files have changed between two commits
- * and outputs the results for use in GitHub Actions workflow conditions.
- *
- * Key behavior:
- * - For PRs: compares PR head against base branch
- * - For pushes: compares HEAD against HEAD^
- * - Excludes certain folders and file types from "code changes" detection
- *
- * Excluded from code changes (don't require changesets):
- * - Markdown files (*.md) in any folder
- * - .changeset/ folder (changeset metadata)
- * - docs/ folder (documentation)
- * - experiments/ folder (experimental scripts)
- * - examples/ folder (example scripts)
- *
- * Usage:
- *   node scripts/detect-code-changes.mjs
- *
- * Environment variables (set by GitHub Actions):
- *   - GITHUB_EVENT_NAME: 'pull_request' or 'push'
- *   - GITHUB_BASE_SHA: Base commit SHA for PR
- *   - GITHUB_HEAD_SHA: Head commit SHA for PR
- *
- * Outputs (written to GITHUB_OUTPUT):
- *   - mjs: 'true' if any .mjs files changed
- *   - js: 'true' if any .js files changed
- *   - package: 'true' if package.json changed
- *   - docs: 'true' if any .md files changed
- *   - workflow: 'true' if any .github/workflows/ files changed
- *   - any-code-changed: 'true' if any code files changed (excludes docs, changesets, experiments, examples)
- */
+// Detect code changes for CI/CD pipeline
+//
+// Detects what types of files changed in the latest commit and outputs
+// results for use in GitHub Actions workflow conditions.
+//
+// For PRs: GitHub Actions checks out a synthetic merge commit, so we
+// compare HEAD^2^ to HEAD^2 (the PR head's per-commit diff).
+// For pushes: compares HEAD^ to HEAD.
+// This ensures a commit touching only non-code files skips tests,
+// even when earlier commits in the same PR changed code.
+//
+// Excluded from code changes (don't require changesets):
+// - Markdown files in any folder
+// - .changeset/ folder (changeset metadata)
+// - docs/ folder (documentation)
+// - experiments/ folder (experimental scripts)
+// - examples/ folder (example scripts)
+//
+// Outputs (written to GITHUB_OUTPUT):
+//   mjs-changed, js-changed, package-changed, docs-changed,
+//   workflow-changed, any-code-changed
 
 import { execSync } from 'child_process';
 import { appendFileSync } from 'fs';
 
-/**
- * Execute a shell command and return trimmed output
- * @param {string} command - The command to execute
- * @returns {string} - The trimmed command output
- */
 function exec(command) {
   try {
     return execSync(command, { encoding: 'utf-8' }).trim();
@@ -53,11 +35,6 @@ function exec(command) {
   }
 }
 
-/**
- * Write output to GitHub Actions output file
- * @param {string} name - Output name
- * @param {string} value - Output value
- */
 function setOutput(name, value) {
   const outputFile = process.env.GITHUB_OUTPUT;
   if (outputFile) {
@@ -66,60 +43,50 @@ function setOutput(name, value) {
   console.log(`${name}=${value}`);
 }
 
-/**
- * Get the list of changed files between two commits
- * @returns {string[]} Array of changed file paths
- */
+function isMergeCommit() {
+  const parentCount = exec('git cat-file -p HEAD')
+    .split('\n')
+    .filter((line) => line.startsWith('parent ')).length;
+  return parentCount > 1;
+}
+
 function getChangedFiles() {
-  const eventName = process.env.GITHUB_EVENT_NAME || 'local';
-
-  if (eventName === 'pull_request') {
-    const baseSha = process.env.GITHUB_BASE_SHA;
-    const headSha = process.env.GITHUB_HEAD_SHA;
-
-    if (baseSha && headSha) {
-      console.log(`Comparing PR: ${baseSha}...${headSha}`);
-      try {
-        // Ensure we have the base commit
-        try {
-          execSync(`git cat-file -e ${baseSha}`, { stdio: 'ignore' });
-        } catch {
-          console.log('Base commit not available locally, attempting fetch...');
-          execSync(`git fetch origin ${baseSha}`, { stdio: 'inherit' });
-        }
-        const output = exec(`git diff --name-only ${baseSha} ${headSha}`);
-        return output ? output.split('\n').filter(Boolean) : [];
-      } catch (error) {
-        console.error(`Git diff failed: ${error.message}`);
-      }
+  // GitHub Actions checks out a synthetic merge commit for pull_request
+  // events: HEAD is the merge commit, HEAD^ is the base branch, HEAD^2
+  // is the actual PR head. To get the per-commit diff (what the latest
+  // push actually changed), we compare HEAD^2^ to HEAD^2.
+  // For push events, HEAD is the real commit, so HEAD^ to HEAD works.
+  if (isMergeCommit()) {
+    console.log('Merge commit detected (pull_request event)');
+    console.log('Comparing HEAD^2^ to HEAD^2 (per-commit diff of PR head)');
+    try {
+      const output = exec('git diff --name-only HEAD^2^ HEAD^2');
+      return output ? output.split('\n').filter(Boolean) : [];
+    } catch {
+      console.log(
+        'HEAD^2^ not available (first commit in PR), listing files in HEAD^2'
+      );
+      const output = exec('git diff --name-only HEAD^ HEAD^2');
+      return output ? output.split('\n').filter(Boolean) : [];
     }
   }
 
-  // For push events or fallback
   console.log('Comparing HEAD^ to HEAD');
   try {
     const output = exec('git diff --name-only HEAD^ HEAD');
     return output ? output.split('\n').filter(Boolean) : [];
   } catch {
-    // If HEAD^ doesn't exist (first commit), list all files in HEAD
     console.log('HEAD^ not available, listing all files in HEAD');
     const output = exec('git ls-tree --name-only -r HEAD');
     return output ? output.split('\n').filter(Boolean) : [];
   }
 }
 
-/**
- * Check if a file should be excluded from code changes detection
- * @param {string} filePath - The file path to check
- * @returns {boolean} True if the file should be excluded
- */
 function isExcludedFromCodeChanges(filePath) {
-  // Exclude markdown files in any folder
   if (filePath.endsWith('.md')) {
     return true;
   }
 
-  // Exclude specific folders from code changes
   const excludedFolders = ['.changeset/', 'docs/', 'experiments/', 'examples/'];
 
   for (const folder of excludedFolders) {
@@ -131,9 +98,6 @@ function isExcludedFromCodeChanges(filePath) {
   return false;
 }
 
-/**
- * Main function to detect changes
- */
 function detectChanges() {
   console.log('Detecting file changes for CI/CD...\n');
 
@@ -147,29 +111,23 @@ function detectChanges() {
   }
   console.log('');
 
-  // Detect .mjs file changes
   const mjsChanged = changedFiles.some((file) => file.endsWith('.mjs'));
   setOutput('mjs-changed', mjsChanged ? 'true' : 'false');
 
-  // Detect .js file changes
   const jsChanged = changedFiles.some((file) => file.endsWith('.js'));
   setOutput('js-changed', jsChanged ? 'true' : 'false');
 
-  // Detect package.json changes
   const packageChanged = changedFiles.some((file) => file === 'package.json');
   setOutput('package-changed', packageChanged ? 'true' : 'false');
 
-  // Detect documentation changes (any .md file)
   const docsChanged = changedFiles.some((file) => file.endsWith('.md'));
   setOutput('docs-changed', docsChanged ? 'true' : 'false');
 
-  // Detect workflow changes
   const workflowChanged = changedFiles.some((file) =>
     file.startsWith('.github/workflows/')
   );
   setOutput('workflow-changed', workflowChanged ? 'true' : 'false');
 
-  // Detect code changes (excluding docs, changesets, experiments, examples folders, and markdown files)
   const codeChangedFiles = changedFiles.filter(
     (file) => !isExcludedFromCodeChanges(file)
   );
@@ -182,10 +140,11 @@ function detectChanges() {
   }
   console.log('');
 
-  // Check if any code files changed (.mjs, .js, .json, .yml, .yaml, or workflow files)
   const codePattern = /\.(mjs|js|json|yml|yaml)$|\.github\/workflows\//;
-  const codeChanged = codeChangedFiles.some((file) => codePattern.test(file));
-  setOutput('any-code-changed', codeChanged ? 'true' : 'false');
+  const anyCodeChanged = codeChangedFiles.some((file) =>
+    codePattern.test(file)
+  );
+  setOutput('any-code-changed', anyCodeChanged ? 'true' : 'false');
 
   console.log('\nChange detection completed.');
 }


### PR DESCRIPTION
## Summary

- **Per-commit diff instead of full-PR diff**: detect-code-changes.mjs now uses `HEAD^2^..HEAD^2` for PR merge commits (GitHub Actions synthetic merge) to evaluate only what the latest push changed, not the entire PR
- **Remove unused env vars**: `GITHUB_BASE_SHA`/`GITHUB_HEAD_SHA` removed from workflow since merge commit detection is self-contained via `git cat-file`
- **Case study**: Root cause analysis with timeline, evidence from web-capture PR #49, and verification plan

Fixes #31

## Root Cause

Two separate issues were causing unnecessary CI runs:

1. **`GITHUB_BASE_SHA...GITHUB_HEAD_SHA` comparison** — the script compared the PR base against the PR head, giving the full PR diff (all files changed across the entire PR)

2. **GitHub Actions synthetic merge commit** — even `HEAD^..HEAD` gives the full PR diff, because GitHub creates a merge commit where `HEAD^` is the base branch

**Evidence**: In [web-capture PR #49](https://github.com/link-assistant/web-capture/pull/49), commit `0e9b6e8c` only modified `.gitkeep` but triggered all 8 CI jobs because the PR as a whole contained code changes.

## Solution

Detect the synthetic merge commit and use `HEAD^2^..HEAD^2` (per-commit diff of the actual PR head):

```javascript
function isMergeCommit() {
  const parentCount = exec('git cat-file -p HEAD')
    .split('\n')
    .filter((line) => line.startsWith('parent ')).length;
  return parentCount > 1;
}
```

- `HEAD` = synthetic merge commit
- `HEAD^` = base branch (first parent)
- `HEAD^2` = actual PR head commit (second parent)
- `HEAD^2^` = PR head commit's parent

For push events, the regular `HEAD^..HEAD` is used.

This follows the same approach implemented and verified in [web-capture PR #51](https://github.com/link-assistant/web-capture/pull/51).

## Files Changed

| File | Change |
|------|--------|
| `scripts/detect-code-changes.mjs` | Replace full-PR diff with per-commit diff via merge commit detection |
| `.github/workflows/release.yml` | Remove unused `GITHUB_BASE_SHA`/`GITHUB_HEAD_SHA` env vars |
| `experiments/test-detect-changes.mjs` | 17 edge-case tests for change classification logic |
| `docs/case-studies/issue-31/README.md` | Case study with root cause analysis and timeline |

## Test plan

- [x] `detect-code-changes.mjs` syntax check passes (`node --check`)
- [x] Script outputs `any-code-changed=false` for `.gitkeep`-only changes (tested locally)
- [x] 17 edge-case tests pass in `experiments/test-detect-changes.mjs`
- [x] ESLint + Prettier pass on all changed files
- [x] Pre-commit hooks pass
- [x] Existing unit tests pass (`npm test`)
- [ ] CI: verify detect-changes job correctly uses per-commit diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)