### PR TITLE
feat: add --tag-prefix option to release scripts for multi-language repos

### DIFF
--- a/.changeset/add-tag-prefix-option.md
+++ b/.changeset/add-tag-prefix-option.md
@@ -1,0 +1,7 @@
+---
+'my-package': minor
+---
+
+Add `--tag-prefix` option to release scripts for multi-language repos
+
+The `create-github-release.mjs` and `format-github-release.mjs` scripts now accept a `--tag-prefix` CLI parameter (defaulting to `v`) that allows users to customize the git tag prefix. This enables use in multi-language repositories where different language packages need distinct tag prefixes (e.g., `js-v1.0.0` vs `rust-v1.0.0`).

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-14T12:50:58.126Z for PR creation at branch issue-36-780ff21d4079 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/36
-# Updated: 2026-04-20T11:22:10.441Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-14T12:50:58.126Z for PR creation at branch issue-36-780ff21d4079 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/36
+# Updated: 2026-04-20T11:22:10.441Z

--- a/docs/case-studies/issue-38/CASE-STUDY.md
+++ b/docs/case-studies/issue-38/CASE-STUDY.md
@@ -1,0 +1,80 @@
+# Case Study: Issue #38 — Tag Prefix Support for Multi-Language Repos
+
+## Timeline / Sequence of Events
+
+1. The JS template was created with `scripts/create-github-release.mjs` and `scripts/format-github-release.mjs`, both hardcoding `v${version}` as the GitHub release tag name.
+2. A downstream multi-language repo ([link-assistant/web-capture](https://github.com/link-assistant/web-capture)) encountered tag collisions when using both the JS template and a Rust template side-by-side: the Rust template uses `rust-v<version>` but the JS template used `v<version>`, causing ambiguity.
+3. [PR #89](https://github.com/link-assistant/web-capture/pull/89) manually patched the tag in that repo as a workaround.
+4. Issue #38 was filed to fix this in the template itself.
+
+## Requirements
+
+1. `scripts/create-github-release.mjs` must support a configurable tag prefix.
+2. `scripts/format-github-release.mjs` must support the same configurable tag prefix.
+3. The default prefix must remain `v` for backward compatibility.
+4. The prefix must be overridable via a `--tag-prefix` CLI argument or `TAG_PREFIX` environment variable.
+5. Downstream users of the template can pass `--tag-prefix "js-v"` without modifying the scripts.
+
+## Root Cause
+
+Both scripts hardcoded the tag construction as `` `v${version}` `` with no parameterization. There was no CLI option, environment variable, or configuration to override this.
+
+## Solution
+
+Added `--tag-prefix` option (defaulting to `'v'`, also readable from `TAG_PREFIX` env var) to both scripts:
+
+```js
+.option('tag-prefix', {
+  type: 'string',
+  default: getenv('TAG_PREFIX', 'v'),
+  describe: 'Prefix for the git tag (e.g., "js-v" for multi-language repos)',
+})
+```
+
+Changed tag construction from:
+
+```js
+const tag = `v${version}`;
+```
+
+to:
+
+```js
+const tag = `${tagPrefix}${version}`;
+```
+
+Also updated the release `name` field from bare `version` to `tag` so the GitHub UI displays the full tag string (e.g., `js-v1.0.0` instead of `1.0.0`).
+
+## Usage
+
+Default (backward-compatible, same as before):
+
+```sh
+node scripts/create-github-release.mjs --release-version 1.0.0 --repository owner/repo
+# creates tag: v1.0.0
+```
+
+Multi-language repo with JS prefix:
+
+```sh
+node scripts/create-github-release.mjs --release-version 1.0.0 --repository owner/repo --tag-prefix "js-v"
+# creates tag: js-v1.0.0
+```
+
+Via environment variable:
+
+```sh
+TAG_PREFIX=js-v node scripts/create-github-release.mjs --release-version 1.0.0 --repository owner/repo
+# creates tag: js-v1.0.0
+```
+
+## Possible Alternatives Considered
+
+- Hardcode `js-v` as the new default: rejected because it breaks existing repos using `v<version>` tags.
+- Use a separate config file: unnecessary complexity for a single scalar value.
+- Use workflow-level env var only: less flexible than a CLI arg (harder to override per-step).
+
+## Related
+
+- [link-assistant/web-capture#88](https://github.com/link-assistant/web-capture/issues/88) — downstream issue
+- [link-assistant/web-capture#89](https://github.com/link-assistant/web-capture/pull/89) — downstream workaround

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -2,9 +2,10 @@
 
 /**
  * Create GitHub Release from CHANGELOG.md
- * Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository>
+ * Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>]
  *   release-version: Version number (e.g., 1.0.0)
  *   repository: GitHub repository (e.g., owner/repo)
+ *   tag-prefix: Prefix for the git tag (default: "v", use "js-v" for multi-language repos)
  *
  * Uses link-foundation libraries:
  * - use-m: Dynamic package loading without package.json dependencies
@@ -37,20 +38,26 @@ const config = makeConfig({
         type: 'string',
         default: getenv('REPOSITORY', ''),
         describe: 'GitHub repository (e.g., owner/repo)',
+      })
+      .option('tag-prefix', {
+        type: 'string',
+        default: getenv('TAG_PREFIX', 'v'),
+        describe:
+          'Prefix for the git tag (e.g., "js-v" for multi-language repos)',
       }),
 });
 
-const { releaseVersion: version, repository } = config;
+const { releaseVersion: version, repository, tagPrefix } = config;
 
 if (!version || !repository) {
   console.error('Error: Missing required arguments');
   console.error(
-    'Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository>'
+    'Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>]'
   );
   process.exit(1);
 }
 
-const tag = `v${version}`;
+const tag = `${tagPrefix}${version}`;
 
 console.log(`Creating GitHub release for ${tag}...`);
 
@@ -78,7 +85,7 @@ try {
   // (Previously caused apostrophes like "didn't" to appear as "didn'''" in releases)
   const payload = JSON.stringify({
     tag_name: tag,
-    name: version,
+    name: tag,
     body: releaseNotes,
   });
 

--- a/scripts/format-github-release.mjs
+++ b/scripts/format-github-release.mjs
@@ -2,10 +2,11 @@
 
 /**
  * Format GitHub release notes using the format-release-notes.mjs script
- * Usage: node scripts/format-github-release.mjs --release-version <version> --repository <repository> --commit-sha <commit_sha>
+ * Usage: node scripts/format-github-release.mjs --release-version <version> --repository <repository> --commit-sha <commit_sha> [--tag-prefix <prefix>]
  *   release-version: Version number (e.g., 1.0.0)
  *   repository: GitHub repository (e.g., owner/repo)
  *   commit_sha: Commit SHA for PR detection
+ *   tag-prefix: Prefix for the git tag (default: "v", use "js-v" for multi-language repos)
  *
  * Uses link-foundation libraries:
  * - use-m: Dynamic package loading without package.json dependencies
@@ -41,20 +42,26 @@ const config = makeConfig({
         type: 'string',
         default: getenv('COMMIT_SHA', ''),
         describe: 'Commit SHA for PR detection',
+      })
+      .option('tag-prefix', {
+        type: 'string',
+        default: getenv('TAG_PREFIX', 'v'),
+        describe:
+          'Prefix for the git tag (e.g., "js-v" for multi-language repos)',
       }),
 });
 
-const { releaseVersion: version, repository, commitSha } = config;
+const { releaseVersion: version, repository, commitSha, tagPrefix } = config;
 
 if (!version || !repository || !commitSha) {
   console.error('Error: Missing required arguments');
   console.error(
-    'Usage: node scripts/format-github-release.mjs --release-version <version> --repository <repository> --commit-sha <commit_sha>'
+    'Usage: node scripts/format-github-release.mjs --release-version <version> --repository <repository> --commit-sha <commit_sha> [--tag-prefix <prefix>]'
   );
   process.exit(1);
 }
 
-const tag = `v${version}`;
+const tag = `${tagPrefix}${version}`;
 
 try {
   // Get the release ID for this version

--- a/tests/tag-prefix.test.js
+++ b/tests/tag-prefix.test.js
@@ -1,0 +1,33 @@
+/**
+ * Tests for --tag-prefix support in create-github-release.mjs and format-github-release.mjs
+ * Reproduces issue #38: tag names should be configurable for multi-language repos
+ */
+
+import { describe, it, expect } from 'test-anywhere';
+
+// Simulate the tag construction logic from both scripts
+function buildTag(version, tagPrefix = 'v') {
+  return `${tagPrefix}${version}`;
+}
+
+describe('tag prefix logic', () => {
+  it('defaults to "v" prefix (backward compatible)', () => {
+    expect(buildTag('1.0.0')).toBe('v1.0.0');
+  });
+
+  it('supports "js-v" prefix for multi-language repos', () => {
+    expect(buildTag('1.0.0', 'js-v')).toBe('js-v1.0.0');
+  });
+
+  it('supports "rust-v" prefix', () => {
+    expect(buildTag('1.7.8', 'rust-v')).toBe('rust-v1.7.8');
+  });
+
+  it('supports empty prefix', () => {
+    expect(buildTag('2.3.4', '')).toBe('2.3.4');
+  });
+
+  it('works with pre-release versions', () => {
+    expect(buildTag('1.0.0-alpha.1', 'js-v')).toBe('js-v1.0.0-alpha.1');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `--tag-prefix` CLI option (and `TAG_PREFIX` env var) to `scripts/create-github-release.mjs` and `scripts/format-github-release.mjs`
- Defaults to `v` for full backward compatibility with existing repos
- Pass `--tag-prefix "js-v"` to generate `js-v1.0.0`-style tags in multi-language repos (e.g., repos with both a JS and a Rust package)
- Updates release `name` field to use the full tag (e.g., `js-v1.0.0`) instead of bare version

## Motivation

In multi-language repos the Rust template uses `rust-v<version>` tags. Without a configurable prefix, JS releases create `v<version>` tags that are ambiguous. Downstream repos had to manually patch the scripts as a workaround ([link-assistant/web-capture#89](https://github.com/link-assistant/web-capture/pull/89)).

## How to reproduce the issue

1. Use this template alongside a Rust template in one repo
2. Trigger a JS release → tag is `v1.0.0` (ambiguous)
3. Trigger a Rust release → tag is `rust-v1.0.0`

## Fix

```sh
# Before (hardcoded):
const tag = `v${version}`;

# After (configurable, backward-compatible default):
const tag = `${tagPrefix}${version}`;
```

## Usage after fix

```sh
# Default (same as before):
node scripts/create-github-release.mjs --release-version 1.0.0 --repository owner/repo
# tag: v1.0.0

# Multi-language repo:
node scripts/create-github-release.mjs --release-version 1.0.0 --repository owner/repo --tag-prefix "js-v"
# tag: js-v1.0.0

# Via env var:
TAG_PREFIX=js-v node scripts/create-github-release.mjs --release-version 1.0.0 --repository owner/repo
# tag: js-v1.0.0
```

## Test plan

- [x] Added `tests/tag-prefix.test.js` with 5 test cases covering default prefix, `js-v`, `rust-v`, empty prefix, and pre-release versions
- [x] All 11 tests pass locally (`npm test`)
- [x] Case study analysis in `docs/case-studies/issue-38/CASE-STUDY.md`

Closes #38