### PR TITLE
CI: add reasonable timeouts to jobs and test runners

### DIFF
--- a/.changeset/calm-ci-timeouts.md
+++ b/.changeset/calm-ci-timeouts.md
@@ -1,0 +1,5 @@
+---
+'my-package': patch
+---
+
+Add explicit CI job timeouts and per-test runner timeout limits.

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,6 +20,9 @@ jobs:
   link-checker:
     name: Check Links
     runs-on: ubuntu-latest
+    # Typical run: <1min with lychee cache. 10min prevents slow
+    # external hosts or Wayback Machine probes from hanging the workflow.
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,9 @@ jobs:
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    # Typical run: ~6s. Cap at 5min so a hung detection step
+    # surfaces quickly instead of stalling the whole pipeline.
+    timeout-minutes: 5
     if: github.event_name != 'workflow_dispatch'
     outputs:
       mjs-changed: ${{ steps.changes.outputs.mjs-changed }}
@@ -70,6 +73,8 @@ jobs:
   test-compilation:
     name: Test Compilation
     runs-on: ubuntu-latest
+    # Typical run: <10s. Tight cap fails fast on syntax-check hangs.
+    timeout-minutes: 5
     needs: [detect-changes]
     if: |
       github.event_name == 'push' ||
@@ -85,6 +90,8 @@ jobs:
   check-file-line-limits:
     name: Check File Line Limits
     runs-on: ubuntu-latest
+    # Typical run: <10s. This job only walks tracked files and counts lines.
+    timeout-minutes: 5
     needs: [detect-changes]
     if: |
       github.event_name == 'push' ||
@@ -110,6 +117,8 @@ jobs:
   version-check:
     name: Check for Manual Version Changes
     runs-on: ubuntu-latest
+    # Typical run: ~6s. Read-only package.json diff inspection.
+    timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v6
@@ -127,6 +136,8 @@ jobs:
   changeset-check:
     name: Check for Changesets
     runs-on: ubuntu-latest
+    # Typical run: <30s including npm install. 10min covers cold runners.
+    timeout-minutes: 10
     needs: [detect-changes]
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
     steps:
@@ -168,6 +179,9 @@ jobs:
   lint:
     name: Lint and Format Check
     runs-on: ubuntu-latest
+    # Typical run: <1min including install, ESLint, Prettier, jscpd,
+    # and secretlint. 10min protects against a hung lint plugin.
+    timeout-minutes: 10
     needs: [detect-changes]
     if: |
       github.event_name == 'push' ||
@@ -215,6 +229,10 @@ jobs:
   test:
     name: Test (${{ matrix.runtime }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # Typical run: <1min per runtime/OS on warm runners, with Windows
+    # sometimes slower on cold starts. 10min fails hung tests well
+    # before GitHub Actions' 6h default.
+    timeout-minutes: 10
     needs:
       [
         detect-changes,
@@ -276,7 +294,9 @@ jobs:
 
       - name: Run tests (Bun)
         if: matrix.runtime == 'bun'
-        run: bun test
+        # --timeout caps an individual test at 30s, matching Node's
+        # --test-timeout budget while leaving headroom for cold runners.
+        run: bun test --timeout 30000
 
       - name: Setup Deno
         if: matrix.runtime == 'deno'
@@ -293,6 +313,8 @@ jobs:
   validate-docs:
     name: Validate Documentation
     runs-on: ubuntu-latest
+    # Typical run: <10s. Pure shell checks over documentation files.
+    timeout-minutes: 5
     needs: [detect-changes]
     if: |
       github.event_name == 'push' ||
@@ -356,6 +378,9 @@ jobs:
   release:
     name: Release
     needs: [lint, test]
+    # Typical run is well under 10min. 30min gives npm and GitHub
+    # release APIs room for retries without allowing a 6h hang.
+    timeout-minutes: 30
     # Use !cancelled() instead of always() so cancellation propagates correctly (hive-mind issue #1278)
     # This is needed because lint/test jobs have a transitive dependency on changeset-check
     if: |
@@ -437,6 +462,8 @@ jobs:
     name: Instant Release
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'instant'
     runs-on: ubuntu-latest
+    # Same publish envelope as the automated release path.
+    timeout-minutes: 30
     # Permissions required for npm OIDC trusted publishing
     permissions:
       contents: write
@@ -486,6 +513,8 @@ jobs:
     name: Create Changeset PR
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changeset-pr'
     runs-on: ubuntu-latest
+    # PR creation only: install, create a changeset, format, and open a PR.
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-14T12:50:58.126Z for PR creation at branch issue-36-780ff21d4079 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/36
+# Updated: 2026-05-03T11:13:53.028Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-14T12:50:58.126Z for PR creation at branch issue-36-780ff21d4079 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/36
-# Updated: 2026-05-03T11:13:53.028Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-14T12:50:58.126Z for PR creation at branch issue-36-780ff21d4079 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/36

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A comprehensive template for AI-driven JavaScript/TypeScript development with fu
 bun install
 
 # Run tests
-bun test
+bun test --timeout 30000
 
 # Or with other runtimes:
 npm test
@@ -135,6 +135,19 @@ The GitHub Actions workflow (`.github/workflows/release.yml`) implements a fast-
 9. **Changeset merge**: Combines multiple pending changesets at release time
 10. **Release**: Automated versioning and npm publishing
 
+#### Reasonable Timeouts
+
+Every CI job declares an explicit `timeout-minutes` so hung steps fail
+in minutes instead of reaching the GitHub Actions default of six hours.
+Fast checks use 5-10 minute caps, release jobs use 30 minutes, and the
+link checker uses 10 minutes for external network variance.
+
+Individual tests are also capped inside supported runners:
+`npm test` runs `node --test --test-timeout=30000`, and the CI Bun
+runner uses `bun test --timeout 30000`. Deno does not provide a single
+global per-test timeout flag, so Deno tests are protected by the
+10-minute matrix job cap.
+
 See [BEST-PRACTICES.md](docs/BEST-PRACTICES.md) for detailed explanations of each practice.
 
 #### Robust Changeset Handling
@@ -199,15 +212,16 @@ Configured in `.prettierrc`:
 
 ## Scripts Reference
 
-| Script                 | Description                             |
-| ---------------------- | --------------------------------------- |
-| `bun test`             | Run tests with Bun                      |
-| `bun run lint`         | Check code with ESLint                  |
-| `bun run lint:fix`     | Fix ESLint issues automatically         |
-| `bun run format`       | Format code with Prettier               |
-| `bun run format:check` | Check formatting without changing files |
-| `bun run check`        | Run all checks (lint + format)          |
-| `bun run changeset`    | Create a new changeset                  |
+| Script                     | Description                                   |
+| -------------------------- | --------------------------------------------- |
+| `bun test --timeout 30000` | Run tests with Bun and a 30s per-test cap     |
+| `npm test`                 | Run tests with Node.js and a 30s per-test cap |
+| `bun run lint`             | Check code with ESLint                        |
+| `bun run lint:fix`         | Fix ESLint issues automatically               |
+| `bun run format`           | Format code with Prettier                     |
+| `bun run format:check`     | Check formatting without changing files       |
+| `bun run check`            | Run all checks (lint + format)                |
+| `bun run changeset`        | Create a new changeset                        |
 
 ## Contributing
 

--- a/docs/BEST-PRACTICES.md
+++ b/docs/BEST-PRACTICES.md
@@ -147,7 +147,51 @@ Documentation files are validated in CI just like code:
 - Required files check (README.md, CHANGELOG.md, CONTRIBUTING.md, BEST-PRACTICES.md)
 - Only runs when documentation files change
 
-### 13. Proper Cancellation Propagation
+### 13. Reasonable Timeouts on Every Job and Test
+
+Every CI job declares an explicit `timeout-minutes`, sized at roughly
+5-10x the typical run time for that job. This keeps feedback fast when
+a test, network call, package install, or release step hangs:
+
+- Fast checks fail within 5-10 minutes instead of waiting for GitHub
+  Actions' six-hour default.
+- Matrix test jobs have a 10-minute cap per runtime and operating
+  system.
+- Release jobs have 30 minutes for package registry and GitHub API
+  retries without allowing an unbounded release run.
+- The broken link checker has 10 minutes for slow external hosts and
+  Web Archive fallback probes.
+
+Current timeout bands:
+
+| Job                       | Cap    |
+| ------------------------- | ------ |
+| `detect-changes`          | 5 min  |
+| `test-compilation`        | 5 min  |
+| `check-file-line-limits`  | 5 min  |
+| `version-check`           | 5 min  |
+| `validate-docs`           | 5 min  |
+| `changeset-check`         | 10 min |
+| `lint`                    | 10 min |
+| `test` per runtime and OS | 10 min |
+| `links.yml` link checker  | 10 min |
+| `changeset-pr`            | 10 min |
+| `release`                 | 30 min |
+| `instant-release`         | 30 min |
+
+Per-test timeouts are also enforced inside the runners that support a
+global budget:
+
+```bash
+node --test --test-timeout=30000 tests/*.test.js
+bun test --timeout 30000
+```
+
+Deno does not currently provide an equivalent single global per-test
+timeout flag, so Deno tests are protected by the 10-minute matrix job
+timeout.
+
+### 14. Proper Cancellation Propagation
 
 Use `!cancelled()` instead of `always()` in job conditions (hive-mind issue #1278):
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Tests should:
 
 ```bash
 # Run tests
-bun test
+bun test --timeout 30000
 npm test
 deno test --allow-read
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "test": "node --test tests/*.test.js",
+    "test": "node --test --test-timeout=30000 tests/*.test.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/tests/ci-timeouts.test.js
+++ b/tests/ci-timeouts.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'test-anywhere';
+import { readFileSync } from 'node:fs';
+
+const releaseWorkflow = readFileSync('.github/workflows/release.yml', 'utf8');
+const linksWorkflow = readFileSync('.github/workflows/links.yml', 'utf8');
+const packageJson = JSON.parse(readFileSync('package.json', 'utf8'));
+
+function listWorkflowJobs(workflow) {
+  const jobsStart = workflow.indexOf('\njobs:\n');
+  const jobsBody = jobsStart === -1 ? '' : workflow.slice(jobsStart);
+  const matches = jobsBody.matchAll(/^[ ]{2}([a-zA-Z0-9_-]+):\s*$/gm);
+
+  return Array.from(matches, (match) => match[1]);
+}
+
+function getJobBlock(workflow, jobName) {
+  const lines = workflow.split('\n');
+  const jobHeader = `  ${jobName}:`;
+  const start = lines.findIndex((line) => line === jobHeader);
+
+  if (start === -1) {
+    return '';
+  }
+
+  const end = lines.findIndex(
+    (line, index) => index > start && /^[ ]{2}[a-zA-Z0-9_-]+:\s*$/.test(line)
+  );
+
+  return lines.slice(start, end === -1 ? lines.length : end).join('\n');
+}
+
+function getTimeoutMinutes(workflow, jobName) {
+  const block = getJobBlock(workflow, jobName);
+  const timeout = block.match(/^[ ]{4}timeout-minutes:\s*(\d+)\s*$/m);
+
+  return timeout ? Number(timeout[1]) : undefined;
+}
+
+describe('CI timeout policy', () => {
+  it('sets timeout-minutes for every release workflow job', () => {
+    const expectedTimeouts = {
+      'detect-changes': 5,
+      'test-compilation': 5,
+      'check-file-line-limits': 5,
+      'version-check': 5,
+      'changeset-check': 10,
+      lint: 10,
+      test: 10,
+      'validate-docs': 5,
+      release: 30,
+      'instant-release': 30,
+      'changeset-pr': 10,
+    };
+
+    expect(listWorkflowJobs(releaseWorkflow).sort()).toEqual(
+      Object.keys(expectedTimeouts).sort()
+    );
+
+    for (const [jobName, timeout] of Object.entries(expectedTimeouts)) {
+      expect(getTimeoutMinutes(releaseWorkflow, jobName)).toBe(timeout);
+    }
+  });
+
+  it('sets timeout-minutes for every link workflow job', () => {
+    expect(listWorkflowJobs(linksWorkflow)).toEqual(['link-checker']);
+    expect(getTimeoutMinutes(linksWorkflow, 'link-checker')).toBe(10);
+  });
+
+  it('caps individual Node.js and Bun tests at 30 seconds', () => {
+    expect(packageJson.scripts.test).toBe(
+      'node --test --test-timeout=30000 tests/*.test.js'
+    );
+    expect(releaseWorkflow).toContain('run: bun test --timeout 30000');
+  });
+});

--- a/tests/ci-timeouts.test.js
+++ b/tests/ci-timeouts.test.js
@@ -1,20 +1,29 @@
 import { describe, it, expect } from 'test-anywhere';
 import { readFileSync } from 'node:fs';
 
-const releaseWorkflow = readFileSync('.github/workflows/release.yml', 'utf8');
-const linksWorkflow = readFileSync('.github/workflows/links.yml', 'utf8');
+const releaseWorkflow = readWorkflow('.github/workflows/release.yml');
+const linksWorkflow = readWorkflow('.github/workflows/links.yml');
 const packageJson = JSON.parse(readFileSync('package.json', 'utf8'));
 
+function readWorkflow(filePath) {
+  return readFileSync(filePath, 'utf8').replaceAll('\r\n', '\n');
+}
+
+function normalizeNewlines(text) {
+  return text.replaceAll('\r\n', '\n');
+}
+
 function listWorkflowJobs(workflow) {
-  const jobsStart = workflow.indexOf('\njobs:\n');
-  const jobsBody = jobsStart === -1 ? '' : workflow.slice(jobsStart);
+  const normalizedWorkflow = normalizeNewlines(workflow);
+  const jobsStart = normalizedWorkflow.indexOf('\njobs:\n');
+  const jobsBody = jobsStart === -1 ? '' : normalizedWorkflow.slice(jobsStart);
   const matches = jobsBody.matchAll(/^[ ]{2}([a-zA-Z0-9_-]+):\s*$/gm);
 
   return Array.from(matches, (match) => match[1]);
 }
 
 function getJobBlock(workflow, jobName) {
-  const lines = workflow.split('\n');
+  const lines = normalizeNewlines(workflow).split('\n');
   const jobHeader = `  ${jobName}:`;
   const start = lines.findIndex((line) => line === jobHeader);
 
@@ -64,6 +73,22 @@ describe('CI timeout policy', () => {
   it('sets timeout-minutes for every link workflow job', () => {
     expect(listWorkflowJobs(linksWorkflow)).toEqual(['link-checker']);
     expect(getTimeoutMinutes(linksWorkflow, 'link-checker')).toBe(10);
+  });
+
+  it('parses workflow files checked out with Windows line endings', () => {
+    const crlfWorkflow = [
+      'name: CRLF fixture',
+      '',
+      'jobs:',
+      '  first-job:',
+      '    timeout-minutes: 5',
+      '  second-job:',
+      '    timeout-minutes: 10',
+      '',
+    ].join('\r\n');
+
+    expect(listWorkflowJobs(crlfWorkflow)).toEqual(['first-job', 'second-job']);
+    expect(getTimeoutMinutes(crlfWorkflow, 'second-job')).toBe(10);
   });
 
   it('caps individual Node.js and Bun tests at 30 seconds', () => {


### PR DESCRIPTION
## Summary

Fixes #46.

- Adds explicit `timeout-minutes` to every job in `.github/workflows/release.yml` and `.github/workflows/links.yml` using 5, 10, and 30 minute bands.
- Adds 30 second per-test caps for Node.js (`npm test`) and the CI Bun runner; Deno remains protected by the matrix job cap because it has no single global per-test timeout flag.
- Documents the timeout policy in README, BEST-PRACTICES, and CONTRIBUTING.
- Adds a regression test that checks workflow job caps and runner timeout flags.

## Reproduction

Before the workflow and script changes, `node --test tests/ci-timeouts.test.js` failed because job-level `timeout-minutes` was missing and `npm test` did not pass `--test-timeout=30000`.

## Verification

- `node --test --test-timeout=30000 tests/ci-timeouts.test.js`
- `npm test`
- `bun test --timeout 30000`
- `deno test --allow-read`
- `npm run check`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `git diff --check`

No UI changes; screenshots are not applicable.