### PR TITLE
fix: check GitHub release creation result

### DIFF
--- a/.changeset/gentle-release-errors.md
+++ b/.changeset/gentle-release-errors.md
@@ -1,0 +1,5 @@
+---
+'my-package': patch
+---
+
+Fail GitHub release creation on unexpected gh api errors and clearly skip releases that already exist.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-14T12:50:58.126Z for PR creation at branch issue-36-780ff21d4079 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/36
+# Updated: 2026-05-03T20:22:28.499Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-14T12:50:58.126Z for PR creation at branch issue-36-780ff21d4079 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/36
-# Updated: 2026-05-03T20:22:28.499Z

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -6,95 +6,184 @@
  *   release-version: Version number (e.g., 1.0.0)
  *   repository: GitHub repository (e.g., owner/repo)
  *   tag-prefix: Prefix for the git tag (default: "v", use "js-v" for multi-language repos)
- *
- * Uses link-foundation libraries:
- * - use-m: Dynamic package loading without package.json dependencies
- * - command-stream: Modern shell command execution with streaming support
- * - lino-arguments: Unified configuration from CLI args, env vars, and .lenv files
  */
 
-import { readFileSync } from 'fs';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-// Load use-m dynamically
-const { use } = eval(
-  await (await fetch('https://unpkg.com/use-m/use.js')).text()
-);
+const USAGE =
+  'Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>]';
 
-// Import link-foundation libraries
-const { $ } = await use('command-stream');
-const { makeConfig } = await use('lino-arguments');
+export function parseArgs(argv, env = process.env) {
+  const config = {
+    releaseVersion: env.VERSION ?? '',
+    repository: env.REPOSITORY ?? '',
+    tagPrefix: env.TAG_PREFIX ?? 'v',
+  };
 
-// Parse CLI arguments using lino-arguments
-// Note: Using --release-version instead of --version to avoid conflict with yargs' built-in --version flag
-const config = makeConfig({
-  yargs: ({ yargs, getenv }) =>
-    yargs
-      .option('release-version', {
-        type: 'string',
-        default: getenv('VERSION', ''),
-        describe: 'Version number (e.g., 1.0.0)',
-      })
-      .option('repository', {
-        type: 'string',
-        default: getenv('REPOSITORY', ''),
-        describe: 'GitHub repository (e.g., owner/repo)',
-      })
-      .option('tag-prefix', {
-        type: 'string',
-        default: getenv('TAG_PREFIX', 'v'),
-        describe:
-          'Prefix for the git tag (e.g., "js-v" for multi-language repos)',
-      }),
-});
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
 
-const { releaseVersion: version, repository, tagPrefix } = config;
+    if (arg === '--release-version') {
+      config.releaseVersion = readOptionValue(argv, index, arg);
+      index++;
+    } else if (arg.startsWith('--release-version=')) {
+      config.releaseVersion = arg.slice('--release-version='.length);
+    } else if (arg === '--repository') {
+      config.repository = readOptionValue(argv, index, arg);
+      index++;
+    } else if (arg.startsWith('--repository=')) {
+      config.repository = arg.slice('--repository='.length);
+    } else if (arg === '--tag-prefix') {
+      config.tagPrefix = readOptionValue(argv, index, arg);
+      index++;
+    } else if (arg.startsWith('--tag-prefix=')) {
+      config.tagPrefix = arg.slice('--tag-prefix='.length);
+    }
+  }
 
-if (!version || !repository) {
-  console.error('Error: Missing required arguments');
-  console.error(
-    'Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>]'
-  );
-  process.exit(1);
+  return config;
 }
 
-const tag = `${tagPrefix}${version}`;
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
 
-console.log(`Creating GitHub release for ${tag}...`);
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
 
-try {
-  // Read CHANGELOG.md
-  const changelog = readFileSync('./CHANGELOG.md', 'utf8');
+  return value;
+}
 
-  // Extract changelog entry for this version
-  // Read from CHANGELOG.md between this version header and the next version header
-  const versionHeaderRegex = new RegExp(`## ${version}[\\s\\S]*?(?=## \\d|$)`);
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function extractReleaseNotes(changelog, version) {
+  // Read from CHANGELOG.md between this version header and the next version header.
+  const versionHeaderRegex = new RegExp(
+    `## ${escapeRegex(version)}[\\s\\S]*?(?=## \\d|$)`
+  );
   const match = changelog.match(versionHeaderRegex);
 
-  let releaseNotes = '';
-  if (match) {
-    // Remove the version header itself and trim
-    releaseNotes = match[0].replace(`## ${version}`, '').trim();
+  if (!match) {
+    return `Release ${version}`;
   }
 
-  if (!releaseNotes) {
-    releaseNotes = `Release ${version}`;
-  }
+  const releaseNotes = match[0].replace(`## ${version}`, '').trim();
 
-  // Create release using GitHub API with JSON input
-  // This avoids shell escaping issues that occur when passing text via command-line arguments
-  // (Previously caused apostrophes like "didn't" to appear as "didn'''" in releases)
-  const payload = JSON.stringify({
+  return releaseNotes || `Release ${version}`;
+}
+
+export function buildReleasePayload({ changelog, tag, version }) {
+  return JSON.stringify({
     tag_name: tag,
     name: tag,
-    body: releaseNotes,
+    body: extractReleaseNotes(changelog, version),
   });
+}
 
-  await $`gh api repos/${repository}/releases -X POST --input -`.run({
-    stdin: payload,
-  });
+function formatGhOutput(result) {
+  return [result.stderr, result.stdout]
+    .filter((output) => typeof output === 'string' && output.trim())
+    .map((output) => output.trim())
+    .join('\n');
+}
 
-  console.log(`\u2705 Created GitHub release: ${tag}`);
-} catch (error) {
-  console.error('Error creating release:', error.message);
-  process.exit(1);
+function getGhExitDescription(result) {
+  if (result.signal) {
+    return `signal ${result.signal}`;
+  }
+
+  if (typeof result.status === 'number') {
+    return `code ${result.status}`;
+  }
+
+  return 'unknown exit status';
+}
+
+export function createRelease({ payload, repository, spawn = spawnSync }) {
+  const result = spawn(
+    'gh',
+    ['api', `repos/${repository}/releases`, '-X', 'POST', '--input', '-'],
+    {
+      encoding: 'utf8',
+      input: payload,
+    }
+  );
+
+  if (result.error) {
+    throw new Error(`gh api failed to start: ${result.error.message}`);
+  }
+
+  if (result.status === 0) {
+    return { alreadyExists: false };
+  }
+
+  const output = formatGhOutput(result);
+
+  if (/already_exists/i.test(output)) {
+    return { alreadyExists: true };
+  }
+
+  const details = output ? `:\n${output}` : '';
+  throw new Error(
+    `gh api failed with ${getGhExitDescription(result)}${details}`
+  );
+}
+
+export function main({
+  argv = process.argv.slice(2),
+  cwd = process.cwd(),
+  env = process.env,
+  spawn = spawnSync,
+  stderr = console.error,
+  stdout = console.log,
+} = {}) {
+  try {
+    const {
+      releaseVersion: version,
+      repository,
+      tagPrefix,
+    } = parseArgs(argv, env);
+
+    if (!version || !repository) {
+      stderr('Error: Missing required arguments');
+      stderr(USAGE);
+      return 1;
+    }
+
+    const tag = `${tagPrefix}${version}`;
+
+    stdout(`Creating GitHub release for ${tag}...`);
+
+    const changelog = readFileSync(path.join(cwd, 'CHANGELOG.md'), 'utf8');
+    const payload = buildReleasePayload({ changelog, tag, version });
+    const result = createRelease({ payload, repository, spawn });
+
+    if (result.alreadyExists) {
+      stdout(`GitHub release already exists: ${tag}. Skipping creation.`);
+      return 0;
+    }
+
+    stdout(`\u2705 Created GitHub release: ${tag}`);
+    return 0;
+  } catch (error) {
+    stderr(`Error creating release: ${error.message}`);
+    return 1;
+  }
+}
+
+function isCliEntryPoint() {
+  return (
+    typeof process !== 'undefined' &&
+    process.argv?.[1] &&
+    fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  );
+}
+
+if (isCliEntryPoint()) {
+  process.exitCode = main();
 }

--- a/tests/create-github-release.test.js
+++ b/tests/create-github-release.test.js
@@ -25,12 +25,22 @@ const canRunCliFixtures =
   !isDenoRuntime && typeof process !== 'undefined' && process.execPath;
 
 function prependPath(env, binPath) {
-  const pathKey =
-    Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+  const nextEnv = { ...env };
+  const currentPath =
+    Object.entries(nextEnv).find(
+      ([key]) => key.toLowerCase() === 'path'
+    )?.[1] ?? '';
+
+  for (const key of Object.keys(nextEnv)) {
+    if (key.toLowerCase() === 'path') {
+      delete nextEnv[key];
+    }
+  }
 
   return {
-    ...env,
-    [pathKey]: `${binPath}${path.delimiter}${env[pathKey] ?? ''}`,
+    ...nextEnv,
+    [process.platform === 'win32' ? 'Path' : 'PATH']:
+      `${binPath}${path.delimiter}${currentPath}`,
   };
 }
 

--- a/tests/create-github-release.test.js
+++ b/tests/create-github-release.test.js
@@ -1,0 +1,203 @@
+/**
+ * Tests for create-github-release.mjs CLI behavior.
+ * Reproduces issue #49: failed gh api calls must not be reported as success.
+ */
+
+import { describe, it, expect } from 'test-anywhere';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, URL } from 'node:url';
+
+const scriptPath = fileURLToPath(
+  new URL('../scripts/create-github-release.mjs', import.meta.url)
+);
+const isDenoRuntime = typeof Deno !== 'undefined';
+const canRunCliFixtures =
+  !isDenoRuntime && typeof process !== 'undefined' && process.execPath;
+
+function prependPath(env, binPath) {
+  const pathKey =
+    Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+
+  return {
+    ...env,
+    [pathKey]: `${binPath}${path.delimiter}${env[pathKey] ?? ''}`,
+  };
+}
+
+function createFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), 'create-release-'));
+  const binPath = path.join(root, 'bin');
+
+  mkdirSync(binPath, { recursive: true });
+  writeFileSync(
+    path.join(root, 'CHANGELOG.md'),
+    `# Changelog
+
+## 1.2.3
+
+### Patch Changes
+
+- Fix release creation
+
+## 1.2.2
+
+- Previous release
+`
+  );
+
+  const fakeGhJs = path.join(binPath, 'fake-gh.js');
+  writeFileSync(
+    fakeGhJs,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+
+const input = fs.readFileSync(0, 'utf8');
+
+if (process.env.FAKE_GH_PAYLOAD_FILE) {
+  fs.writeFileSync(process.env.FAKE_GH_PAYLOAD_FILE, input);
+}
+
+if (process.env.FAKE_GH_ARGS_FILE) {
+  fs.writeFileSync(
+    process.env.FAKE_GH_ARGS_FILE,
+    JSON.stringify(process.argv.slice(2))
+  );
+}
+
+if (process.env.FAKE_GH_MODE === 'success') {
+  console.log(JSON.stringify({ id: 123 }));
+  process.exit(0);
+}
+
+if (process.env.FAKE_GH_MODE === 'already_exists') {
+  console.error('gh: Validation Failed (HTTP 422)');
+  console.error('already_exists');
+  process.exit(1);
+}
+
+console.error('gh: synthetic server error');
+process.exit(1);
+`
+  );
+
+  const fakeGhPath = path.join(binPath, 'gh');
+  writeFileSync(
+    fakeGhPath,
+    `#!/bin/sh
+exec "${process.execPath}" "$(dirname "$0")/fake-gh.js" "$@"
+`
+  );
+  chmodSync(fakeGhPath, 0o755);
+
+  writeFileSync(
+    path.join(binPath, 'gh.cmd'),
+    `@echo off\r\n"${process.execPath}" "%~dp0fake-gh.js" %*\r\n`
+  );
+
+  return root;
+}
+
+function runCreateRelease(root, mode) {
+  const argsFile = path.join(root, 'gh-args.json');
+  const payloadFile = path.join(root, 'gh-payload.json');
+  const binPath = path.join(root, 'bin');
+  const env = prependPath(
+    {
+      ...process.env,
+      FAKE_GH_ARGS_FILE: argsFile,
+      FAKE_GH_MODE: mode,
+      FAKE_GH_PAYLOAD_FILE: payloadFile,
+    },
+    binPath
+  );
+
+  return {
+    argsFile,
+    payloadFile,
+    result: spawnSync(
+      process.execPath,
+      [scriptPath, '--release-version', '1.2.3', '--repository', 'owner/repo'],
+      {
+        cwd: root,
+        encoding: 'utf8',
+        env,
+      }
+    ),
+  };
+}
+
+describe('create-github-release.mjs', () => {
+  if (canRunCliFixtures) {
+    it('passes release payload to gh api and reports success only on exit code 0', () => {
+      const root = createFixture();
+
+      try {
+        const { argsFile, payloadFile, result } = runCreateRelease(
+          root,
+          'success'
+        );
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain('Creating GitHub release for v1.2.3');
+        expect(result.stdout).toContain('Created GitHub release: v1.2.3');
+        expect(JSON.parse(readFileSync(argsFile, 'utf8'))).toEqual([
+          'api',
+          'repos/owner/repo/releases',
+          '-X',
+          'POST',
+          '--input',
+          '-',
+        ]);
+        expect(JSON.parse(readFileSync(payloadFile, 'utf8'))).toEqual({
+          tag_name: 'v1.2.3',
+          name: 'v1.2.3',
+          body: '### Patch Changes\n\n- Fix release creation',
+        });
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('fails when gh api exits non-zero with an unexpected error', () => {
+      const root = createFixture();
+
+      try {
+        const { result } = runCreateRelease(root, 'failure');
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain('Creating GitHub release for v1.2.3');
+        expect(result.stdout).not.toContain('Created GitHub release');
+        expect(result.stderr).toContain('gh api failed with code 1');
+        expect(result.stderr).toContain('synthetic server error');
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('treats already_exists as an explicit idempotent skip', () => {
+      const root = createFixture();
+
+      try {
+        const { result } = runCreateRelease(root, 'already_exists');
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain(
+          'GitHub release already exists: v1.2.3. Skipping creation.'
+        );
+        expect(result.stdout).not.toContain('Created GitHub release');
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/tests/create-github-release.test.js
+++ b/tests/create-github-release.test.js
@@ -17,12 +17,27 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, URL } from 'node:url';
 
+import { createRelease } from '../scripts/create-github-release.mjs';
+
 const scriptPath = fileURLToPath(
   new URL('../scripts/create-github-release.mjs', import.meta.url)
 );
 const isDenoRuntime = typeof Deno !== 'undefined';
+const isBunRuntime =
+  typeof process !== 'undefined' && Boolean(process.versions?.bun);
+const isNodeRuntime =
+  typeof process !== 'undefined' &&
+  Boolean(process.versions?.node) &&
+  !isBunRuntime &&
+  !isDenoRuntime;
+const isWindowsNodeRuntime = isNodeRuntime && process.platform === 'win32';
+// Node on Windows does not execute the .cmd gh fixture through spawnSync.
+// The injected-spawn tests below cover release result handling on that runner.
 const canRunCliFixtures =
-  !isDenoRuntime && typeof process !== 'undefined' && process.execPath;
+  !isDenoRuntime &&
+  !isWindowsNodeRuntime &&
+  typeof process !== 'undefined' &&
+  process.execPath;
 
 function prependPath(env, binPath) {
   const nextEnv = { ...env };
@@ -146,7 +161,89 @@ function runCreateRelease(root, mode) {
   };
 }
 
+function createSpawnRecorder(result) {
+  const calls = [];
+
+  return {
+    calls,
+    spawn(command, args, options) {
+      calls.push({ args, command, options });
+      return result;
+    },
+  };
+}
+
 describe('create-github-release.mjs', () => {
+  it('uses gh api and reports successful creation only for exit code 0', () => {
+    const payload = JSON.stringify({ tag_name: 'v1.2.3' });
+    const { calls, spawn } = createSpawnRecorder({
+      status: 0,
+      stderr: '',
+      stdout: JSON.stringify({ id: 123 }),
+    });
+
+    expect(createRelease({ payload, repository: 'owner/repo', spawn })).toEqual(
+      {
+        alreadyExists: false,
+      }
+    );
+    expect(calls).toEqual([
+      {
+        args: [
+          'api',
+          'repos/owner/repo/releases',
+          '-X',
+          'POST',
+          '--input',
+          '-',
+        ],
+        command: 'gh',
+        options: {
+          encoding: 'utf8',
+          input: payload,
+        },
+      },
+    ]);
+  });
+
+  it('throws when gh api exits non-zero with an unexpected error', () => {
+    const { spawn } = createSpawnRecorder({
+      status: 1,
+      stderr: 'gh: synthetic server error',
+      stdout: '',
+    });
+    let thrownError;
+
+    try {
+      createRelease({
+        payload: '{}',
+        repository: 'owner/repo',
+        spawn,
+      });
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError.message).toContain('gh api failed with code 1');
+    expect(thrownError.message).toContain('synthetic server error');
+  });
+
+  it('treats already_exists as an idempotent gh api result', () => {
+    const { spawn } = createSpawnRecorder({
+      status: 1,
+      stderr: 'already_exists',
+      stdout: '',
+    });
+
+    expect(
+      createRelease({
+        payload: '{}',
+        repository: 'owner/repo',
+        spawn,
+      })
+    ).toEqual({ alreadyExists: true });
+  });
+
   if (canRunCliFixtures) {
     it('passes release payload to gh api and reports success only on exit code 0', () => {
       const root = createFixture();


### PR DESCRIPTION
## Summary

Fixes #49.

- Replace the `command-stream` GitHub release creation call with native `gh api` subprocess handling that checks the process status before logging success.
- Fail unexpected non-zero `gh api` exits so release jobs cannot go green after a release creation failure.
- Treat GitHub `already_exists` validation errors as an explicit idempotent skip instead of reporting a new release as created.
- Add regression coverage for command-result handling with injected spawn results, plus a fake `gh` executable CLI fixture for success, unexpected failure, and `already_exists` behavior.

## Reproduction Covered

`tests/create-github-release.test.js` verifies that a non-zero `gh api` result exits as failure and does not print `Created GitHub release`. It covers the core command-result logic directly across runtimes, and exercises the CLI against a fake `gh` executable where the fixture can be executed by the runner.

## Tests

- `node --test --test-timeout=30000 tests/create-github-release.test.js`
- `npm test`
- `bun test --timeout 30000`
- `deno test --allow-read`
- `npm run lint`
- `npm run format:check`
- `npm run check:duplication`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`

CI passing on `0c993011de1e88e0187591fc2ccb660bdf23e049`:

- Broken Link Checker: https://github.com/link-foundation/js-ai-driven-development-pipeline-template/actions/runs/25290287228
- Checks and release: https://github.com/link-foundation/js-ai-driven-development-pipeline-template/actions/runs/25290287367
