### PR TITLE
Fix GitHub release titles for prefixed tags

### DIFF
--- a/.changeset/release-title-language.md
+++ b/.changeset/release-title-language.md
@@ -1,0 +1,5 @@
+---
+'my-package': patch
+---
+
+Format GitHub release names as human-readable `[Language] x.y.z` titles while keeping prefixed tag names unchanged.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-14T12:50:58.126Z for PR creation at branch issue-36-780ff21d4079 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/36
+# Updated: 2026-05-09T03:02:37.634Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-14T12:50:58.126Z for PR creation at branch issue-36-780ff21d4079 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/36
-# Updated: 2026-05-09T03:02:37.634Z

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -2,10 +2,11 @@
 
 /**
  * Create GitHub Release from CHANGELOG.md
- * Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>]
+ * Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>]
  *   release-version: Version number (e.g., 1.0.0)
  *   repository: GitHub repository (e.g., owner/repo)
  *   tag-prefix: Prefix for the git tag (default: "v", use "js-v" for multi-language repos)
+ *   language: Human-readable language name for the release title (default: "JavaScript")
  */
 
 import { spawnSync } from 'node:child_process';
@@ -14,10 +15,11 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const USAGE =
-  'Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>]';
+  'Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>]';
 
 export function parseArgs(argv, env = process.env) {
   const config = {
+    language: env.LANGUAGE ?? 'JavaScript',
     releaseVersion: env.VERSION ?? '',
     repository: env.REPOSITORY ?? '',
     tagPrefix: env.TAG_PREFIX ?? 'v',
@@ -41,6 +43,11 @@ export function parseArgs(argv, env = process.env) {
       index++;
     } else if (arg.startsWith('--tag-prefix=')) {
       config.tagPrefix = arg.slice('--tag-prefix='.length);
+    } else if (arg === '--language') {
+      config.language = readOptionValue(argv, index, arg);
+      index++;
+    } else if (arg.startsWith('--language=')) {
+      config.language = arg.slice('--language='.length);
     }
   }
 
@@ -77,10 +84,30 @@ export function extractReleaseNotes(changelog, version) {
   return releaseNotes || `Release ${version}`;
 }
 
-export function buildReleasePayload({ changelog, tag, version }) {
+export function normalizeReleaseVersionForTitle(releaseVersion) {
+  const trimmedVersion = releaseVersion.trim();
+  const semverTagMatch = trimmedVersion.match(
+    /(?:^|[-_])v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/i
+  );
+
+  if (semverTagMatch) {
+    return semverTagMatch[1];
+  }
+
+  return trimmedVersion
+    .replace(/^[A-Za-z][A-Za-z0-9]*[-_]/, '')
+    .replace(/^v/i, '');
+}
+
+export function buildReleaseTitle(language, releaseVersion) {
+  const titleLanguage = language.trim() || 'JavaScript';
+  return `[${titleLanguage}] ${normalizeReleaseVersionForTitle(releaseVersion)}`;
+}
+
+export function buildReleasePayload({ changelog, language, tag, version }) {
   return JSON.stringify({
     tag_name: tag,
-    name: tag,
+    name: buildReleaseTitle(language ?? 'JavaScript', tag),
     body: extractReleaseNotes(changelog, version),
   });
 }
@@ -144,6 +171,7 @@ export function main({
 } = {}) {
   try {
     const {
+      language,
       releaseVersion: version,
       repository,
       tagPrefix,
@@ -160,7 +188,7 @@ export function main({
     stdout(`Creating GitHub release for ${tag}...`);
 
     const changelog = readFileSync(path.join(cwd, 'CHANGELOG.md'), 'utf8');
-    const payload = buildReleasePayload({ changelog, tag, version });
+    const payload = buildReleasePayload({ changelog, language, tag, version });
     const result = createRelease({ payload, repository, spawn });
 
     if (result.alreadyExists) {

--- a/tests/create-github-release.test.js
+++ b/tests/create-github-release.test.js
@@ -1,6 +1,7 @@
 /**
  * Tests for create-github-release.mjs CLI behavior.
  * Reproduces issue #49: failed gh api calls must not be reported as success.
+ * Reproduces issue #52: release names should be human-readable titles.
  */
 
 import { describe, it, expect } from 'test-anywhere';
@@ -17,7 +18,11 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, URL } from 'node:url';
 
-import { createRelease } from '../scripts/create-github-release.mjs';
+import {
+  buildReleasePayload,
+  createRelease,
+  parseArgs,
+} from '../scripts/create-github-release.mjs';
 
 const scriptPath = fileURLToPath(
   new URL('../scripts/create-github-release.mjs', import.meta.url)
@@ -132,7 +137,7 @@ exec "${process.execPath}" "$(dirname "$0")/fake-gh.js" "$@"
   return root;
 }
 
-function runCreateRelease(root, mode) {
+function runCreateRelease(root, mode, extraArgs = []) {
   const argsFile = path.join(root, 'gh-args.json');
   const payloadFile = path.join(root, 'gh-payload.json');
   const binPath = path.join(root, 'bin');
@@ -151,7 +156,14 @@ function runCreateRelease(root, mode) {
     payloadFile,
     result: spawnSync(
       process.execPath,
-      [scriptPath, '--release-version', '1.2.3', '--repository', 'owner/repo'],
+      [
+        scriptPath,
+        '--release-version',
+        '1.2.3',
+        '--repository',
+        'owner/repo',
+        ...extraArgs,
+      ],
       {
         cwd: root,
         encoding: 'utf8',
@@ -172,6 +184,59 @@ function createSpawnRecorder(result) {
     },
   };
 }
+
+describe('create-github-release release title formatting', () => {
+  it('parses language from CLI arguments and environment defaults', () => {
+    expect(parseArgs([], {})).toEqual({
+      language: 'JavaScript',
+      releaseVersion: '',
+      repository: '',
+      tagPrefix: 'v',
+    });
+    expect(parseArgs([], { LANGUAGE: 'TypeScript' })).toEqual({
+      language: 'TypeScript',
+      releaseVersion: '',
+      repository: '',
+      tagPrefix: 'v',
+    });
+    expect(parseArgs(['--language', 'JavaScript'], {})).toEqual({
+      language: 'JavaScript',
+      releaseVersion: '',
+      repository: '',
+      tagPrefix: 'v',
+    });
+    expect(parseArgs(['--language=Rust'], {})).toEqual({
+      language: 'Rust',
+      releaseVersion: '',
+      repository: '',
+      tagPrefix: 'v',
+    });
+  });
+
+  it('builds a human-readable release name from a language-prefixed tag', () => {
+    const changelog = `# Changelog
+
+## 1.2.3
+
+- Fix release creation
+`;
+
+    expect(
+      JSON.parse(
+        buildReleasePayload({
+          changelog,
+          language: 'JavaScript',
+          tag: 'js-v1.2.3',
+          version: '1.2.3',
+        })
+      )
+    ).toEqual({
+      tag_name: 'js-v1.2.3',
+      name: '[JavaScript] 1.2.3',
+      body: '- Fix release creation',
+    });
+  });
+});
 
 describe('create-github-release.mjs', () => {
   it('uses gh api and reports successful creation only for exit code 0', () => {
@@ -267,7 +332,32 @@ describe('create-github-release.mjs', () => {
         ]);
         expect(JSON.parse(readFileSync(payloadFile, 'utf8'))).toEqual({
           tag_name: 'v1.2.3',
-          name: 'v1.2.3',
+          name: '[JavaScript] 1.2.3',
+          body: '### Patch Changes\n\n- Fix release creation',
+        });
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('passes a human-readable release name for language-prefixed tags', () => {
+      const root = createFixture();
+
+      try {
+        const { payloadFile, result } = runCreateRelease(root, 'success', [
+          '--tag-prefix',
+          'js-v',
+          '--language',
+          'JavaScript',
+        ]);
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain(
+          'Creating GitHub release for js-v1.2.3'
+        );
+        expect(JSON.parse(readFileSync(payloadFile, 'utf8'))).toEqual({
+          tag_name: 'js-v1.2.3',
+          name: '[JavaScript] 1.2.3',
           body: '### Patch Changes\n\n- Fix release creation',
         });
       } finally {


### PR DESCRIPTION
Fixes #52

## Summary

- Adds `--language` / `LANGUAGE` support to `scripts/create-github-release.mjs`, defaulting to `JavaScript`.
- Builds GitHub release names as `[Language] x.y.z` by normalizing prefixed tags like `js-v0.3.5`, while keeping `tag_name` unchanged.
- Adds regression coverage for release payload creation and the fake-`gh` CLI path.
- Adds a patch changeset and removes the temporary root `.gitkeep`.

## Reproduction

Before this fix, `--tag-prefix js-v --release-version 1.2.3` sent a release payload whose `name` was `js-v1.2.3`.

The new regression test verifies the payload now keeps:

```json
{
  "tag_name": "js-v1.2.3",
  "name": "[JavaScript] 1.2.3"
}
```

## Verification

- `node --test --test-timeout=30000 tests/create-github-release.test.js`
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run check:duplication`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`
