### PR TITLE
feat: Add optional Docker Hub publishing tied to npm releases

### DIFF
--- a/.changeset/docker-hub-publishing.md
+++ b/.changeset/docker-hub-publishing.md
@@ -1,0 +1,6 @@
+---
+'my-package': minor
+---
+
+Add an optional Docker Hub publishing path that waits for the exact npm
+package version before tagging Docker images.

--- a/.github/actions/publish-dockerhub/action.yml
+++ b/.github/actions/publish-dockerhub/action.yml
@@ -1,0 +1,58 @@
+name: Publish Docker Hub Image
+description: Publish a Docker image to Docker Hub with npm release tags.
+
+inputs:
+  context:
+    description: Docker build context path.
+    required: false
+    default: .
+  file:
+    description: Dockerfile path.
+    required: false
+    default: ./Dockerfile
+  image:
+    description: Docker Hub image name, for example namespace/image.
+    required: true
+  token:
+    description: Docker Hub access token.
+    required: true
+  username:
+    description: Docker Hub username.
+    required: true
+  version:
+    description: Published npm package version used for the Docker tag.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ inputs.username }}
+        password: ${{ inputs.token }}
+
+    - name: Extract Docker metadata
+      id: metadata
+      uses: docker/metadata-action@v6
+      with:
+        images: ${{ inputs.image }}
+        tags: |
+          type=raw,value=latest
+          type=raw,value=${{ inputs.version }}
+        labels: |
+          org.opencontainers.image.version=${{ inputs.version }}
+
+    - name: Publish Docker image to Docker Hub
+      uses: docker/build-push-action@v7
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        push: true
+        tags: ${{ steps.metadata.outputs.tags }}
+        labels: ${{ steps.metadata.outputs.labels }}
+        build-args: |
+          NPM_PACKAGE_VERSION=${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,6 +395,9 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    outputs:
+      published: ${{ steps.publish.outputs.published }}
+      published_version: ${{ steps.publish.outputs.published_version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -469,6 +472,9 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    outputs:
+      published: ${{ steps.publish.outputs.published }}
+      published_version: ${{ steps.publish.outputs.published_version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -507,6 +513,51 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/format-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}"
+
+  # Optional Docker Hub publishing for packages that also ship Docker images.
+  # Set vars.DOCKERHUB_IMAGE to enable this path, then configure
+  # vars.DOCKERHUB_USERNAME and secrets.DOCKERHUB_TOKEN.
+  docker-publish:
+    name: Optional Docker Hub Publish
+    needs: [release, instant-release]
+    timeout-minutes: 30
+    if: |
+      !cancelled() &&
+      (
+        (needs.release.result == 'success' && needs.release.outputs.published == 'true') ||
+        (needs.instant-release.result == 'success' && needs.instant-release.outputs.published == 'true')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      DOCKER_CONTEXT: ${{ vars.DOCKER_CONTEXT }}
+      DOCKERFILE: ${{ vars.DOCKERFILE }}
+      DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+      RELEASE_VERSION: ${{ needs.release.outputs.published_version || needs.instant-release.outputs.published_version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check Docker publish configuration
+        id: docker_config
+        run: node scripts/check-docker-publish.mjs
+
+      - name: Wait for npm package availability before Docker publish
+        if: steps.docker_config.outputs.enabled == 'true'
+        run: node scripts/wait-for-npm.mjs --release-version "${{ env.RELEASE_VERSION }}"
+
+      - name: Publish Docker image to Docker Hub
+        if: steps.docker_config.outputs.enabled == 'true'
+        uses: ./.github/actions/publish-dockerhub
+        with:
+          context: ${{ steps.docker_config.outputs.context }}
+          file: ${{ steps.docker_config.outputs.dockerfile }}
+          image: ${{ steps.docker_config.outputs.image }}
+          token: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          version: ${{ env.RELEASE_VERSION }}
 
   # Manual Changeset PR - creates a pull request with the changeset for review
   changeset-pr:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-09T20:34:11.755Z for PR creation at branch issue-54-483e7bfb6b4f for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/54

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-09T20:34:11.755Z for PR creation at branch issue-54-483e7bfb6b4f for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/54

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A comprehensive template for AI-driven JavaScript/TypeScript development with fu
 - **Multi-runtime support**: Works with Bun, Node.js, and Deno
 - **Universal testing**: Uses [test-anywhere](https://github.com/link-foundation/test-anywhere) for cross-runtime tests
 - **Automated releases**: Changesets-based versioning with GitHub Actions
+- **Optional Docker Hub publishing**: Docker images can be published after the matching npm version is visible
 - **Code quality**: ESLint + Prettier with pre-commit hooks via Husky
 - **Package manager agnostic**: Works with bun, npm, yarn, pnpm, and deno
 - **Broken link checks**: Automated link validation with [lychee](https://github.com/lycheeverse/lychee-action) and Web Archive fallback suggestions
@@ -103,7 +104,8 @@ The release workflow uses [Changesets](https://github.com/changesets/changesets)
 2. **PR validation**: CI checks for valid changeset in each PR
 3. **Automated versioning**: Merging to `main` triggers version bump
 4. **npm publishing**: Automated via OIDC trusted publishing (no tokens needed)
-5. **GitHub releases**: Auto-created with formatted release notes
+5. **Optional Docker Hub publishing**: When configured, waits for the exact npm version and tags the Docker image with that version
+6. **GitHub releases**: Auto-created with formatted release notes
 
 #### Manual Releases
 
@@ -134,6 +136,7 @@ The GitHub Actions workflow (`.github/workflows/release.yml`) implements a fast-
 
 9. **Changeset merge**: Combines multiple pending changesets at release time
 10. **Release**: Automated versioning and npm publishing
+11. **Optional Docker publish**: Publishes Docker Hub `latest` and npm-version tags after the npm package is visible
 
 #### Reasonable Timeouts
 
@@ -187,6 +190,24 @@ After creating a repository from this template, update the package name in:
 
 Release scripts derive the package name from `package.json` at runtime, so no
 script-level package-name constants need to be edited during template adoption.
+
+### Optional Docker Hub Publishing
+
+Docker publishing is disabled by default. To enable it for a project that ships
+a Docker image, add a `Dockerfile` and configure these GitHub Actions settings:
+
+| Setting              | Type               | Description                                                                           |
+| -------------------- | ------------------ | ------------------------------------------------------------------------------------- |
+| `DOCKERHUB_IMAGE`    | Variable           | Docker Hub image name, for example `namespace/image`. This enables Docker publishing. |
+| `DOCKERHUB_USERNAME` | Variable           | Docker Hub username used by `docker/login-action`.                                    |
+| `DOCKERHUB_TOKEN`    | Secret             | Docker Hub access token used for registry authentication.                             |
+| `DOCKER_CONTEXT`     | Variable, optional | Docker build context. Defaults to `.`.                                                |
+| `DOCKERFILE`         | Variable, optional | Dockerfile path. Defaults to `./Dockerfile`.                                          |
+
+When enabled, the release workflow waits until the exact published npm version
+is visible in the npm registry, then publishes Docker Hub tags for `latest` and
+that same version. The Docker build also receives `NPM_PACKAGE_VERSION` as a
+build argument so Dockerfiles can install the matching published package.
 
 ### ESLint Rules
 

--- a/docs/BEST-PRACTICES.md
+++ b/docs/BEST-PRACTICES.md
@@ -78,6 +78,7 @@ Automated release workflows ensure:
 - **OIDC trusted publishing** - No API tokens needed in CI
 - **Validated releases only** - All checks must pass before publishing
 - **Dual trigger modes** - Both automatic (on merge) and manual (workflow dispatch)
+- **Optional Docker Hub publishing** - Projects with Docker images can publish version-matched Docker tags after npm package availability is confirmed
 
 ### 8. CI/CD Pipeline Features
 
@@ -178,6 +179,7 @@ Current timeout bands:
 | `changeset-pr`            | 10 min |
 | `release`                 | 30 min |
 | `instant-release`         | 30 min |
+| `docker-publish`          | 30 min |
 
 Per-test timeouts are also enforced inside the runners that support a
 global budget:
@@ -218,6 +220,7 @@ Developer Machine    ->    CI/CD Pipeline               ->    Release
                           ├── Slow checks (~1-10 min)
                           │   └── test matrix (9 combos)
                           ├── Documentation validation
+                          ├── Optional Docker Hub publish
                           └── Changeset verify
 ```
 

--- a/scripts/check-docker-publish.mjs
+++ b/scripts/check-docker-publish.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+/**
+ * Validate optional Docker Hub publish configuration.
+ *
+ * Docker publishing is opt-in. Set DOCKERHUB_IMAGE to enable it, then provide:
+ * - DOCKERHUB_USERNAME: Docker Hub account name
+ * - DOCKERHUB_TOKEN: Docker Hub access token
+ * - DOCKERFILE: Dockerfile path (optional, defaults to ./Dockerfile)
+ * - DOCKER_CONTEXT: build context path (optional, defaults to .)
+ */
+
+import { appendFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_CONTEXT = '.';
+const DEFAULT_DOCKERFILE = './Dockerfile';
+
+function clean(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function hasExplicitTag(image) {
+  const lastSegment = image.split('/').at(-1) ?? '';
+  return lastSegment.includes(':');
+}
+
+function normalizeRelativePath(value, fallback) {
+  return clean(value) || fallback;
+}
+
+function fileExists(cwd, filePath) {
+  return existsSync(path.resolve(cwd, filePath));
+}
+
+function directoryExists(cwd, directoryPath) {
+  return existsSync(path.resolve(cwd, directoryPath));
+}
+
+export function evaluateDockerPublishConfig({
+  cwd = process.cwd(),
+  env = process.env,
+} = {}) {
+  const image = clean(env.DOCKERHUB_IMAGE);
+  const username = clean(env.DOCKERHUB_USERNAME);
+  const token = clean(env.DOCKERHUB_TOKEN);
+  const context = normalizeRelativePath(env.DOCKER_CONTEXT, DEFAULT_CONTEXT);
+  const dockerfile = normalizeRelativePath(env.DOCKERFILE, DEFAULT_DOCKERFILE);
+  const errors = [];
+
+  if (!image) {
+    return {
+      context,
+      dockerfile,
+      enabled: false,
+      errors,
+      image,
+      username,
+    };
+  }
+
+  if (/\s/.test(image)) {
+    errors.push('DOCKERHUB_IMAGE must not contain whitespace');
+  }
+
+  if (hasExplicitTag(image)) {
+    errors.push(
+      'DOCKERHUB_IMAGE must not include a tag; release tags are generated from npm'
+    );
+  }
+
+  if (!username) {
+    errors.push('DOCKERHUB_USERNAME is required when DOCKERHUB_IMAGE is set');
+  }
+
+  if (!token) {
+    errors.push('DOCKERHUB_TOKEN is required when DOCKERHUB_IMAGE is set');
+  }
+
+  if (!directoryExists(cwd, context)) {
+    errors.push(`Docker context does not exist: ${context}`);
+  }
+
+  if (!fileExists(cwd, dockerfile)) {
+    errors.push(`Dockerfile does not exist: ${dockerfile}`);
+  }
+
+  return {
+    context,
+    dockerfile,
+    enabled: errors.length === 0,
+    errors,
+    image,
+    username,
+  };
+}
+
+function setOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${name}=${value}\n`);
+  }
+  console.log(`Output: ${name}=${value}`);
+}
+
+function isCliEntryPoint() {
+  return (
+    typeof process !== 'undefined' &&
+    process.argv?.[1] &&
+    fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  );
+}
+
+export function main({ env = process.env, stderr = console.error } = {}) {
+  const config = evaluateDockerPublishConfig({ env });
+
+  setOutput('enabled', config.enabled ? 'true' : 'false');
+  setOutput('context', config.context);
+  setOutput('dockerfile', config.dockerfile);
+  setOutput('image', config.image);
+
+  if (!config.image) {
+    console.log(
+      'Docker Hub publishing is disabled: DOCKERHUB_IMAGE is not set'
+    );
+    return 0;
+  }
+
+  if (config.errors.length > 0) {
+    for (const error of config.errors) {
+      stderr(`::error::${error}`);
+    }
+    return 1;
+  }
+
+  console.log(`Docker Hub publishing is enabled for ${config.image}`);
+  return 0;
+}
+
+if (isCliEntryPoint()) {
+  process.exitCode = main();
+}

--- a/scripts/wait-for-npm.mjs
+++ b/scripts/wait-for-npm.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+
+/**
+ * Wait for a package version to become available on npm.
+ *
+ * The Docker publish job runs after npm publishing, but npm registry visibility
+ * can lag briefly. Waiting here keeps Docker tags tied to an installable npm
+ * version.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { formatNpmPackageVersion, readPackageInfo } from './package-info.mjs';
+
+const DEFAULT_MAX_ATTEMPTS = 30;
+const DEFAULT_SLEEP_SECONDS = 10;
+const USAGE =
+  'Usage: node scripts/wait-for-npm.mjs --release-version <version> [--package-name <name>] [--max-attempts <count>] [--sleep-seconds <count>] [--js-root <path>]';
+
+function parsePositiveInteger(value, optionName) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${optionName} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function readCliOptions(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+
+    const inlineValueIndex = arg.indexOf('=');
+    if (inlineValueIndex !== -1) {
+      options[arg.slice(2, inlineValueIndex)] = arg.slice(inlineValueIndex + 1);
+      continue;
+    }
+
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    options[arg.slice(2)] = value;
+    index++;
+  }
+
+  return options;
+}
+
+export function parseArgs(argv, env = process.env) {
+  const cliOptions = readCliOptions(argv);
+
+  const config = {
+    jsRoot: cliOptions['js-root'] ?? env.JS_ROOT ?? '',
+    maxAttempts: parsePositiveInteger(
+      cliOptions['max-attempts'] ||
+        env.MAX_ATTEMPTS ||
+        String(DEFAULT_MAX_ATTEMPTS),
+      '--max-attempts'
+    ),
+    packageName: cliOptions['package-name'] ?? env.PACKAGE_NAME ?? '',
+    releaseVersion: cliOptions['release-version'] ?? env.VERSION ?? '',
+    sleepSeconds: parsePositiveInteger(
+      cliOptions['sleep-seconds'] ||
+        env.SLEEP_SECONDS ||
+        String(DEFAULT_SLEEP_SECONDS),
+      '--sleep-seconds'
+    ),
+  };
+
+  return config;
+}
+
+export function checkNpmVersion(packageName, version) {
+  try {
+    const publishedVersion = execFileSync(
+      'npm',
+      ['view', formatNpmPackageVersion(packageName, version), 'version'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+    ).trim();
+
+    return publishedVersion === version;
+  } catch {
+    return false;
+  }
+}
+
+function sleep(seconds) {
+  return new Promise((resolve) =>
+    globalThis.setTimeout(resolve, seconds * 1000)
+  );
+}
+
+function setOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${name}=${value}\n`);
+  }
+  console.log(`Output: ${name}=${value}`);
+}
+
+export async function waitForNpmVersion({
+  checkAvailability = checkNpmVersion,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  packageName,
+  sleepFn = sleep,
+  sleepSeconds = DEFAULT_SLEEP_SECONDS,
+  stdout = console.log,
+  version,
+}) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    stdout(
+      `Checking npm for ${formatNpmPackageVersion(packageName, version)} (attempt ${attempt}/${maxAttempts})`
+    );
+
+    if (checkAvailability(packageName, version)) {
+      return true;
+    }
+
+    if (attempt < maxAttempts) {
+      await sleepFn(sleepSeconds);
+    }
+  }
+
+  return false;
+}
+
+function isCliEntryPoint() {
+  return (
+    typeof process !== 'undefined' &&
+    process.argv?.[1] &&
+    fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  );
+}
+
+export async function main({
+  argv = process.argv.slice(2),
+  env = process.env,
+  stderr = console.error,
+  stdout = console.log,
+} = {}) {
+  try {
+    const config = parseArgs(argv, env);
+    if (!config.releaseVersion) {
+      stderr('Error: Missing required --release-version');
+      stderr(USAGE);
+      return 1;
+    }
+
+    const packageInfo = config.packageName
+      ? { name: config.packageName }
+      : readPackageInfo({ jsRoot: config.jsRoot || undefined });
+
+    const available = await waitForNpmVersion({
+      maxAttempts: config.maxAttempts,
+      packageName: packageInfo.name,
+      sleepSeconds: config.sleepSeconds,
+      stdout,
+      version: config.releaseVersion,
+    });
+
+    setOutput('npm_available', available ? 'true' : 'false');
+
+    if (!available) {
+      stderr(
+        `${formatNpmPackageVersion(packageInfo.name, config.releaseVersion)} did not become available on npm`
+      );
+      return 1;
+    }
+
+    stdout(
+      `${formatNpmPackageVersion(packageInfo.name, config.releaseVersion)} is available on npm`
+    );
+    return 0;
+  } catch (error) {
+    stderr(`Error: ${error.message}`);
+    return 1;
+  }
+}
+
+if (isCliEntryPoint()) {
+  process.exitCode = await main();
+}

--- a/tests/ci-timeouts.test.js
+++ b/tests/ci-timeouts.test.js
@@ -58,6 +58,7 @@ describe('CI timeout policy', () => {
       'validate-docs': 5,
       release: 30,
       'instant-release': 30,
+      'docker-publish': 30,
       'changeset-pr': 10,
     };
 

--- a/tests/docker-publish.test.js
+++ b/tests/docker-publish.test.js
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'test-anywhere';
+import { readFileSync } from 'node:fs';
+
+import { evaluateDockerPublishConfig } from '../scripts/check-docker-publish.mjs';
+import { parseArgs, waitForNpmVersion } from '../scripts/wait-for-npm.mjs';
+
+const releaseWorkflow = readFileSync('.github/workflows/release.yml', 'utf8');
+const dockerHubAction = readFileSync(
+  '.github/actions/publish-dockerhub/action.yml',
+  'utf8'
+);
+
+function getWorkflowJob(workflow, jobName) {
+  const lines = workflow.replaceAll('\r\n', '\n').split('\n');
+  const start = lines.findIndex((line) => line === `  ${jobName}:`);
+  if (start === -1) {
+    return '';
+  }
+
+  const nextJob = lines.findIndex(
+    (line, index) => index > start && /^[ ]{2}[a-zA-Z0-9_-]+:\s*$/.test(line)
+  );
+  return lines.slice(start, nextJob === -1 ? lines.length : nextJob).join('\n');
+}
+
+function expectOrdered(text, markers) {
+  let lastIndex = -1;
+
+  for (const marker of markers) {
+    const index = text.indexOf(marker);
+    expect(index).toBeGreaterThan(lastIndex);
+    lastIndex = index;
+  }
+}
+
+describe('optional Docker Hub publishing workflow', () => {
+  it('adds a Docker publish job downstream of npm release jobs', () => {
+    const dockerJob = getWorkflowJob(releaseWorkflow, 'docker-publish');
+
+    expect(dockerJob).toContain('needs: [release, instant-release]');
+    expect(dockerJob).toContain('DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}');
+    expect(dockerJob).toContain(
+      'DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}'
+    );
+    expect(dockerJob).toContain(
+      'DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}'
+    );
+    expect(dockerJob).toContain(
+      'RELEASE_VERSION: ${{ needs.release.outputs.published_version || needs.instant-release.outputs.published_version }}'
+    );
+  });
+
+  it('waits for the exact npm version before publishing Docker tags', () => {
+    const dockerJob = getWorkflowJob(releaseWorkflow, 'docker-publish');
+
+    expectOrdered(dockerJob, [
+      '- name: Check Docker publish configuration',
+      '- name: Wait for npm package availability before Docker publish',
+      '- name: Publish Docker image to Docker Hub',
+    ]);
+    expect(dockerJob).toContain(
+      'node scripts/wait-for-npm.mjs --release-version "${{ env.RELEASE_VERSION }}"'
+    );
+    expect(dockerHubAction).toContain('type=raw,value=${{ inputs.version }}');
+    expect(dockerHubAction).toContain(
+      'org.opencontainers.image.version=${{ inputs.version }}'
+    );
+    expect(dockerHubAction).toContain(
+      'NPM_PACKAGE_VERSION=${{ inputs.version }}'
+    );
+  });
+
+  it('uses Docker official GitHub Actions with DOCKERHUB_TOKEN authentication', () => {
+    expect(dockerHubAction).toContain('uses: docker/setup-buildx-action@v4');
+    expect(dockerHubAction).toContain('uses: docker/login-action@v4');
+    expect(dockerHubAction).toContain('password: ${{ inputs.token }}');
+    expect(dockerHubAction).toContain('uses: docker/metadata-action@v6');
+    expect(dockerHubAction).toContain('uses: docker/build-push-action@v7');
+  });
+});
+
+describe('Docker publish configuration', () => {
+  it('keeps Docker publishing disabled until DOCKERHUB_IMAGE is configured', () => {
+    const config = evaluateDockerPublishConfig({
+      env: {},
+    });
+
+    expect(config.enabled).toBe(false);
+    expect(config.errors).toEqual([]);
+  });
+
+  it('reports missing Docker Hub credentials when publishing is enabled', () => {
+    const config = evaluateDockerPublishConfig({
+      cwd: '.',
+      env: {
+        DOCKERFILE: 'package.json',
+        DOCKERHUB_IMAGE: 'owner/image',
+      },
+    });
+
+    expect(config.enabled).toBe(false);
+    expect(config.errors).toContain(
+      'DOCKERHUB_USERNAME is required when DOCKERHUB_IMAGE is set'
+    );
+    expect(config.errors).toContain(
+      'DOCKERHUB_TOKEN is required when DOCKERHUB_IMAGE is set'
+    );
+  });
+
+  it('accepts complete Docker Hub configuration without exposing the token', () => {
+    const config = evaluateDockerPublishConfig({
+      cwd: '.',
+      env: {
+        DOCKER_CONTEXT: '.',
+        DOCKERFILE: 'package.json',
+        DOCKERHUB_IMAGE: 'owner/image',
+        DOCKERHUB_TOKEN: 'secret-token',
+        DOCKERHUB_USERNAME: 'owner',
+      },
+    });
+
+    expect(config).toEqual({
+      context: '.',
+      dockerfile: 'package.json',
+      enabled: true,
+      errors: [],
+      image: 'owner/image',
+      username: 'owner',
+    });
+  });
+});
+
+describe('wait-for-npm.mjs', () => {
+  it('parses release wait options', () => {
+    expect(
+      parseArgs(
+        [
+          '--release-version',
+          '1.2.3',
+          '--package-name=@scope/pkg',
+          '--max-attempts',
+          '2',
+          '--sleep-seconds=1',
+        ],
+        {}
+      )
+    ).toEqual({
+      jsRoot: '',
+      maxAttempts: 2,
+      packageName: '@scope/pkg',
+      releaseVersion: '1.2.3',
+      sleepSeconds: 1,
+    });
+  });
+
+  it('retries until npm reports the requested version', async () => {
+    let attempts = 0;
+    const sleeps = [];
+
+    const available = await waitForNpmVersion({
+      checkAvailability(packageName, version) {
+        attempts++;
+        expect(packageName).toBe('@scope/pkg');
+        expect(version).toBe('1.2.3');
+        return attempts === 2;
+      },
+      maxAttempts: 3,
+      packageName: '@scope/pkg',
+      sleepFn(seconds) {
+        sleeps.push(seconds);
+        return Promise.resolve();
+      },
+      sleepSeconds: 1,
+      stdout() {},
+      version: '1.2.3',
+    });
+
+    expect(available).toBe(true);
+    expect(sleeps).toEqual([1]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #54.

Adds an opt-in Docker Hub publishing path to the release workflow. When `DOCKERHUB_IMAGE` is configured, the Docker job now waits for the exact npm package version to become visible before publishing `latest` and version-matched Docker Hub tags.

## Implementation

- Adds `.github/actions/publish-dockerhub`, composed from Docker's official setup, login, metadata, and build-push actions.
- Adds `docker-publish` after both npm release paths, using release job outputs for the published version.
- Adds `scripts/check-docker-publish.mjs` to keep Docker publishing disabled by default and fail fast on incomplete Docker Hub config.
- Adds `scripts/wait-for-npm.mjs` so Docker image tags are only published after `npm view <package>@<version>` reports the same version.
- Adds static tests for release ordering, version-tag parity, official Docker action usage, config validation, and npm wait behavior.
- Documents the required GitHub Actions variables/secrets and adds a changeset.

## Reproduction / Verification

The issue is reproduced and guarded by `tests/docker-publish.test.js`, which verifies that Docker publishing waits for the npm availability step before publishing image tags and that Docker tags/labels/build args use the same release version.

Local checks run:

- `node --test --test-timeout=30000 tests/docker-publish.test.js`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `npm test`
- `npm run check`
- `bun test --timeout 30000`
- `deno test --allow-read`
- `npx --yes -p secretlint -p @secretlint/secretlint-rule-preset-recommend secretlint "**/*"`
