### PR TITLE
docs: document Settings → Pages → Source = GitHub Actions prerequisite

### DIFF
--- a/.changeset/document-pages-source-prerequisite.md
+++ b/.changeset/document-pages-source-prerequisite.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Document the one-time **Settings → Pages → Source = GitHub Actions** prerequisite for the example app deployment, and note it in a comment above the `pages-deploy` job.

--- a/.github/workflows/example-app.yml
+++ b/.github/workflows/example-app.yml
@@ -70,6 +70,9 @@ jobs:
         with:
           path: examples/universal-app/dist
 
+  # Requires Settings → Pages → Source = GitHub Actions to be set once
+  # in the repository before this job can succeed. See README → "Deploying
+  # the example app". The Pages source cannot be configured from a workflow.
   pages-deploy:
     name: Deploy GitHub Pages
     needs: [web-build]

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-12T15:18:09.847Z for PR creation at branch issue-58-4fd60491b94f for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/58
+# Updated: 2026-05-12T22:59:25.452Z

--- a/README.md
+++ b/README.md
@@ -196,6 +196,18 @@ The CI/CD pipeline is designed to handle concurrent PRs gracefully:
 
 This design decouples PR validation from the need to pull changes from the default branch, reducing conflicts and ensuring that even if CI/CD fails, all unpublished changesets will still get published when the error is resolved.
 
+### Deploying the example app
+
+The `example-app.yml` workflow deploys the universal example app to GitHub
+Pages on every push to `main`. Before the first run on `main` in a new
+repository created from this template, open **Settings → Pages** and set
+**Source = GitHub Actions**. This is a one-time manual step and cannot be
+configured from a workflow because the Pages source defaults to
+_Deploy from a branch_. Without it, the `pages-deploy` job fails on
+`actions/deploy-pages` with `Get Pages site failed` /
+`Failed to create deployment`. After flipping the source, the workflow
+provisions the Pages site on its first run.
+
 ### Broken Link Checker
 
 The link checker workflow (`.github/workflows/links.yml`) validates all links in Markdown and HTML files:


### PR DESCRIPTION
## Summary

Fixes #60.

Documents the one-time **Settings → Pages → Source = GitHub Actions** step that downstream repositories must perform before the `example-app.yml` `pages-deploy` job can succeed for the first time. The Pages source defaults to *Deploy from a branch* and cannot be flipped from a workflow, so without this step `actions/deploy-pages` fails with `Get Pages site failed` / `Failed to create deployment`.

## Changes

- **`README.md`** — adds a new `### Deploying the example app` section in the Design Choices block, with the exact wording suggested in the issue plus the specific error messages users will see if they skip it.
- **`.github/workflows/example-app.yml`** — adds a three-line comment directly above the `pages-deploy` job pointing back to that README section, so anyone reading the workflow understands the prerequisite without needing to grep for it.
- **`.changeset/document-pages-source-prerequisite.md`** — patch-level changeset for the docs-only change.

## How to reproduce the original issue

1. Bootstrap a new repository from this template.
2. Push to `main` without changing repository settings.
3. The `pages-deploy` job fails on `actions/deploy-pages@v5` with `Get Pages site failed`.
4. Set **Settings → Pages → Source = GitHub Actions**, re-run; the deploy succeeds.

The README change makes step 1–3 avoidable for future template users.

## Test plan

- [x] `npm run check` (lint + prettier + jscpd) passes locally
- [x] `npx changeset status` shows the new patch bump for `@link-foundation/example-package-name`
- [x] Diff is docs-only — no code paths changed