### PR TITLE
fix: Correct CI workflow reliability policy

### DIFF
--- a/.changeset/steady-ci-policy.md
+++ b/.changeset/steady-ci-policy.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Correct CI workflow concurrency and preview failure artifact handling in the template.

--- a/.github/workflows/example-app.yml
+++ b/.github/workflows/example-app.yml
@@ -29,7 +29,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   web-build:
@@ -261,6 +261,18 @@ jobs:
           # will pick up these fresh images for the regular pages-build.
           git commit -m "chore(preview): regenerate example-app preview images [skip ci]"
           git push origin HEAD:main
+
+      - name: Upload screenshot failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: preview-regen-failure-${{ github.run_id }}
+          path: |
+            docs/screenshots/
+            web/test-results/
+            web/playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Summarize regeneration result
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,13 @@ on:
         type: string
 
 # Concurrency: Only one workflow run per branch at a time
-# - For main branch (releases): cancel older runs to prevent blocking newer releases
-#   When multiple commits are pushed quickly, we want the latest to release, not wait
-# - For PR branches: queue runs to avoid cancelling checks on force-pushes
+# - For main branch (releases): let runs finish so a newer push does not cancel
+#   an in-flight publish or release update.
+# - For PR branches: cancel older runs so new pushes supersede stale checks.
 # See: docs/case-studies/issue-25/DETAILED-COMPARISON.md for context
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # === DETECT CHANGES - determines which jobs should run ===

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-12T15:18:09.847Z for PR creation at branch issue-58-4fd60491b94f for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/58
 # Updated: 2026-05-12T22:59:25.452Z
 # Updated: 2026-05-15T07:39:21.510Z
-# Updated: 2026-05-20T12:09:48.793Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-12T15:18:09.847Z for PR creation at branch issue-58-4fd60491b94f for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/58
 # Updated: 2026-05-12T22:59:25.452Z
 # Updated: 2026-05-15T07:39:21.510Z
+# Updated: 2026-05-20T12:09:48.793Z

--- a/docs/BEST-PRACTICES.md
+++ b/docs/BEST-PRACTICES.md
@@ -82,20 +82,20 @@ Automated release workflows ensure:
 
 ### 8. CI/CD Pipeline Features
 
-The workflow implements several critical features from hive-mind issues #1274 and #1278:
+The workflow implements several critical features from hive-mind issues #1274 and #1278, plus template reliability fixes:
 
 #### Concurrency Control
 
 ```yaml
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 ```
 
 This configuration (implemented in this template) ensures:
 
-- **Main branch**: Newer runs cancel older runs, preventing blocking (Issue #1274 fix)
-- **PR branches**: Runs are queued to preserve check history
+- **Main branch**: Runs finish without newer pushes cancelling in-flight release work
+- **PR branches**: Newer pushes cancel stale runs to save CI minutes and avoid racing checks
 
 See [DETAILED-COMPARISON.md](./case-studies/issue-25/DETAILED-COMPARISON.md) for the full analysis of best practices from both repositories.
 

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'test-anywhere';
+import { readFileSync } from 'node:fs';
+
+function readWorkflow(filePath) {
+  return readFileSync(filePath, 'utf8').replaceAll('\r\n', '\n');
+}
+
+function getJobBlock(workflow, jobName) {
+  const lines = workflow.split('\n');
+  const jobHeader = `  ${jobName}:`;
+  const start = lines.findIndex((line) => line === jobHeader);
+
+  if (start === -1) {
+    return '';
+  }
+
+  const end = lines.findIndex(
+    (line, index) => index > start && /^[ ]{2}[a-zA-Z0-9_-]+:\s*$/.test(line)
+  );
+
+  return lines.slice(start, end === -1 ? lines.length : end).join('\n');
+}
+
+describe('workflow reliability policy', () => {
+  it('cancels superseded non-main runs without cancelling main runs', () => {
+    const workflowPaths = [
+      '.github/workflows/example-app.yml',
+      '.github/workflows/release.yml',
+    ];
+
+    for (const workflowPath of workflowPaths) {
+      const workflow = readWorkflow(workflowPath);
+
+      expect(workflow).toContain(
+        'group: ${{ github.workflow }}-${{ github.ref }}'
+      );
+      expect(workflow).toContain(
+        "cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}"
+      );
+      expect(workflow).not.toContain(
+        "cancel-in-progress: ${{ github.ref == 'refs/heads/main' }}"
+      );
+    }
+  });
+
+  it('uploads preview regeneration artifacts when screenshot rendering fails', () => {
+    const exampleAppWorkflow = readWorkflow(
+      '.github/workflows/example-app.yml'
+    );
+    const previewRegenJob = getJobBlock(exampleAppWorkflow, 'preview-regen');
+
+    expect(previewRegenJob).toContain(
+      'name: Upload screenshot failure artifacts'
+    );
+    expect(previewRegenJob).toContain('if: failure()');
+    expect(previewRegenJob).toContain('uses: actions/upload-artifact@v7');
+    expect(previewRegenJob).toContain(
+      'name: preview-regen-failure-${{ github.run_id }}'
+    );
+    expect(previewRegenJob).toContain('docs/screenshots/');
+    expect(previewRegenJob).toContain('web/test-results/');
+    expect(previewRegenJob).toContain('web/playwright-report/');
+    expect(previewRegenJob).toContain('retention-days: 7');
+    expect(previewRegenJob).toContain('if-no-files-found: ignore');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #64.

- Correct `cancel-in-progress` in `example-app.yml` and `release.yml` so main runs are not cancelled while PR/non-main runs supersede stale pushes.
- Add `preview-regen` failure artifact upload for generated screenshots and Playwright output paths.
- Update best-practices documentation and add a workflow reliability regression test covering both issues.
- Add a patch changeset for the shipped template workflow fix.

## Reproduction

Before the workflow fix, `node --test --test-timeout=30000 tests/workflow-reliability.test.js` failed because the workflows still used `github.ref == 'refs/heads/main'` and the `preview-regen` job had no failure artifact upload step.

## Tests

- `node --test --test-timeout=30000 tests/workflow-reliability.test.js` (failed before the fix, passes after)
- `npm test`
- `npm run check`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `GITHUB_BASE_REF=main GITHUB_BASE_SHA=$(git rev-parse origin/main) GITHUB_HEAD_SHA=$(git rev-parse HEAD) node scripts/validate-changeset.mjs`
- `git diff --check`
