### PR TITLE
ci: enforce line limits for JavaScript and Markdown files

### DIFF
--- a/.changeset/enforce-js-md-line-limits.md
+++ b/.changeset/enforce-js-md-line-limits.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Enforce the 1500-line architecture limit across all JavaScript (`.js`, `.mjs`, `.cjs`) and Markdown (`.md`) files in the `check-file-line-limits` CI gate, lower the documentation limit from 2500 to 1500, and exempt case-study generated-data files explicitly.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,7 @@ jobs:
       github.event_name == 'push' ||
       needs.detect-changes.outputs.mjs-changed == 'true' ||
       needs.detect-changes.outputs.js-changed == 'true' ||
+      needs.detect-changes.outputs.docs-changed == 'true' ||
       needs.detect-changes.outputs.workflow-changed == 'true'
     steps:
       - uses: actions/checkout@v6
@@ -109,6 +110,9 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: bash scripts/simulate-fresh-merge.sh
 
+      # Enforces the 1500-line limit on JavaScript (.js/.mjs/.cjs) and
+      # Markdown (.md) files plus release.yml. This is the single source
+      # of truth for the line limit; validate-docs no longer re-checks it.
       - name: Check file line limits
         run: bash scripts/check-file-line-limits.sh
 
@@ -322,30 +326,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Check documentation file sizes
-        run: |
-          LIMIT=2500
-          FAILURES=()
-
-          echo "Checking that documentation files are under ${LIMIT} lines..."
-
-          while IFS= read -r -d '' file; do
-            line_count=$(wc -l < "$file")
-            if [ "$line_count" -gt "$LIMIT" ]; then
-              echo "ERROR: $file has $line_count lines (limit: ${LIMIT})"
-              echo "::error file=$file::Documentation file has $line_count lines (limit: ${LIMIT})"
-              FAILURES+=("$file")
-            fi
-          done < <(find docs -name "*.md" -type f -print0 2>/dev/null)
-
-          if [ "${#FAILURES[@]}" -gt 0 ]; then
-            echo "The following docs exceed the ${LIMIT} line limit:"
-            printf '  %s\n' "${FAILURES[@]}"
-            exit 1
-          else
-            echo "All documentation files are within the ${LIMIT} line limit."
-          fi
-
+      # Documentation line limits (1500 lines, matching the architecture
+      # limit) are enforced by the check-file-line-limits job, which scans
+      # every .md file. This job only validates required-file presence.
       - name: Check required documentation files exist
         run: |
           REQUIRED_FILES=(

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-12T15:18:09.847Z for PR creation at branch issue-58-4fd60491b94f for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/58
 # Updated: 2026-05-12T22:59:25.452Z
 # Updated: 2026-05-15T07:39:21.510Z
+# Updated: 2026-05-29T20:51:12.469Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-12T15:18:09.847Z for PR creation at branch issue-58-4fd60491b94f for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/58
 # Updated: 2026-05-12T22:59:25.452Z
 # Updated: 2026-05-15T07:39:21.510Z
-# Updated: 2026-05-29T20:51:12.469Z

--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ The GitHub Actions workflow (`.github/workflows/release.yml`) implements a fast-
 
 1. **Test compilation**: Syntax-checks all `.mjs` files with `node --check`
 2. **Lint, format & secrets scan**: ESLint, Prettier, jscpd, and [secretlint](https://github.com/secretlint/secretlint) for credential leak detection
-3. **File line limits**: Enforces 1500-line limit on `.mjs` files and `release.yml`
+3. **File line limits**: Enforces the 1500-line limit on JavaScript (`.js`, `.mjs`, `.cjs`) and Markdown (`.md`) files plus `release.yml`
 4. **Changeset check**: Validates PR has exactly one changeset (added by that PR)
 5. **Version check**: Blocks manual version changes in `package.json`
-6. **Documentation validation**: Checks doc file sizes and required files
+6. **Documentation validation**: Checks required doc files (doc line limits are enforced by the file line limits check)
 
 **Slow checks** (only run after all fast checks pass):
 

--- a/docs/BEST-PRACTICES.md
+++ b/docs/BEST-PRACTICES.md
@@ -125,12 +125,13 @@ Slow test matrix only runs after all fast checks pass. This dramatically reduces
 
 ### 10. File Line Limits in CI
 
-In addition to the ESLint `max-lines` rule (which only covers source files), a separate CI check enforces the 1500-line limit on:
+In addition to the ESLint `max-lines` rule (which only covers the source files it lints), a separate CI check enforces the 1500-line limit on:
 
-- All `.mjs` files (including scripts)
+- All JavaScript files (`.js`, `.mjs`, `.cjs`, including scripts)
+- All Markdown files (`.md`, including documentation)
 - `.github/workflows/release.yml` (to prevent workflow bloat)
 
-This is enforced by `scripts/check-file-line-limits.sh`.
+This is enforced by `scripts/check-file-line-limits.sh`. Case-study and generated-data files under `docs/case-studies/*/data/` are exempt because they mirror external sources verbatim (the same paths are ignored by ESLint).
 
 ### 11. Secrets Detection
 
@@ -144,7 +145,7 @@ Automated scanning for accidental credential leaks using [secretlint](https://gi
 
 Documentation files are validated in CI just like code:
 
-- File size limits (2500 lines for docs)
+- File size limits (1500 lines, enforced by the `check-file-line-limits` job alongside JavaScript files)
 - Required files check (README.md, CHANGELOG.md, CONTRIBUTING.md, BEST-PRACTICES.md)
 - Only runs when documentation files change
 

--- a/scripts/check-file-line-limits.sh
+++ b/scripts/check-file-line-limits.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 # check-file-line-limits.sh
 #
-# Enforces a 1500-line limit on all .mjs files and on release.yml.
+# Enforces the documented 1500-line architecture limit on tracked
+# JavaScript (.js, .mjs, .cjs) and Markdown (.md) files, plus
+# .github/workflows/release.yml.
+#
+# This shell gate complements the ESLint `max-lines` rule: ESLint only
+# covers source files it lints, while this check walks every tracked
+# JavaScript and Markdown file so .js, .cjs, and documentation cannot
+# slip past the limit.
+#
+# Intentional exceptions (kept in sync with the eslint.config.js ignore
+# list): case-study and generated-data files under
+# docs/case-studies/*/data/ mirror external sources verbatim and must not
+# be reflowed to satisfy the limit, so they are excluded here.
 #
 # Usage:
 #   bash scripts/check-file-line-limits.sh
@@ -15,37 +27,45 @@ WARN_THRESHOLD=1350
 FAILURES=()
 WARNINGS=()
 
-echo "Checking that all .mjs files are under ${LIMIT} lines..."
-
-while IFS= read -r -d '' file; do
+# check_file FILE [HINT]
+# Counts lines in FILE and records a warning or failure when it crosses
+# the warning threshold or hard limit. HINT is appended to the GitHub
+# annotation to suggest a remediation.
+check_file() {
+  local file="$1"
+  local hint="${2:-Extract code to keep files under the ${LIMIT} line limit.}"
+  local line_count
   line_count=$(wc -l < "$file" | tr -d '[:space:]')
   echo "$file: $line_count lines"
   if [ "$line_count" -gt "$LIMIT" ]; then
     echo "ERROR: $file has $line_count lines (limit: ${LIMIT})"
-    echo "::error file=$file::File has $line_count lines (limit: ${LIMIT})"
+    echo "::error file=$file::File has $line_count lines (limit: ${LIMIT}). ${hint}"
     FAILURES+=("$file")
   elif [ "$line_count" -gt "$WARN_THRESHOLD" ]; then
     echo "WARNING: $file has $line_count lines (approaching limit of ${LIMIT}, warning threshold: ${WARN_THRESHOLD})"
-    echo "::warning file=$file::File has $line_count lines (approaching limit of ${LIMIT}). Consider extracting code to keep under ${WARN_THRESHOLD} lines and prevent concurrent PR merge limit violations."
+    echo "::warning file=$file::File has $line_count lines (approaching limit of ${LIMIT}). ${hint}"
     WARNINGS+=("$file")
   fi
-done < <(find . -name "*.mjs" -type f -not -path "*/node_modules/*" -print0)
+}
+
+echo "Checking that JavaScript and Markdown files are under ${LIMIT} lines..."
+
+# Walk every tracked JavaScript and Markdown file. node_modules is build
+# output, and docs/case-studies/*/data holds verbatim external sources
+# (see header note and eslint.config.js ignores).
+while IFS= read -r -d '' file; do
+  check_file "$file"
+done < <(find . -type f \
+  \( -name "*.js" -o -name "*.mjs" -o -name "*.cjs" -o -name "*.md" \) \
+  -not -path "*/node_modules/*" \
+  -not -path "./docs/case-studies/*/data/*" \
+  -print0)
 
 echo ""
 echo "Checking that .github/workflows/release.yml is under ${LIMIT} lines..."
 RELEASE_YML=".github/workflows/release.yml"
 if [ -f "$RELEASE_YML" ]; then
-  line_count=$(wc -l < "$RELEASE_YML" | tr -d '[:space:]')
-  echo "$RELEASE_YML: $line_count lines"
-  if [ "$line_count" -gt "$LIMIT" ]; then
-    echo "ERROR: $RELEASE_YML has $line_count lines (limit: ${LIMIT})"
-    echo "::error file=$RELEASE_YML::File has $line_count lines (limit: ${LIMIT}). Move inline scripts to ./scripts/ folder."
-    FAILURES+=("$RELEASE_YML")
-  elif [ "$line_count" -gt "$WARN_THRESHOLD" ]; then
-    echo "WARNING: $RELEASE_YML has $line_count lines (approaching limit of ${LIMIT}, warning threshold: ${WARN_THRESHOLD})"
-    echo "::warning file=$RELEASE_YML::File has $line_count lines (approaching limit of ${LIMIT}). Consider moving inline scripts to ./scripts/ folder."
-    WARNINGS+=("$RELEASE_YML")
-  fi
+  check_file "$RELEASE_YML" "Move inline scripts to the ./scripts/ folder to reduce file size."
 else
   echo "WARNING: $RELEASE_YML not found, skipping"
 fi

--- a/scripts/detect-code-changes.mjs
+++ b/scripts/detect-code-changes.mjs
@@ -114,7 +114,9 @@ function detectChanges() {
   const mjsChanged = changedFiles.some((file) => file.endsWith('.mjs'));
   setOutput('mjs-changed', mjsChanged ? 'true' : 'false');
 
-  const jsChanged = changedFiles.some((file) => file.endsWith('.js'));
+  const jsChanged = changedFiles.some(
+    (file) => file.endsWith('.js') || file.endsWith('.cjs')
+  );
   setOutput('js-changed', jsChanged ? 'true' : 'false');
 
   const packageChanged = changedFiles.some((file) => file === 'package.json');
@@ -140,7 +142,7 @@ function detectChanges() {
   }
   console.log('');
 
-  const codePattern = /\.(mjs|js|json|yml|yaml)$|\.github\/workflows\//;
+  const codePattern = /\.(mjs|cjs|js|json|yml|yaml)$|\.github\/workflows\//;
   const anyCodeChanged = codeChangedFiles.some((file) =>
     codePattern.test(file)
   );

--- a/tests/check-file-line-limits.test.js
+++ b/tests/check-file-line-limits.test.js
@@ -106,6 +106,70 @@ describe('check-file-line-limits.sh', () => {
       }
     });
 
+    it('fails .js and .cjs files over the hard limit', () => {
+      const root = createFixture({
+        'src/too-large.js': 1501,
+        'src/legacy.cjs': 1600,
+      });
+
+      try {
+        const result = runLineLimitCheck(root);
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain(
+          'ERROR: ./src/too-large.js has 1501 lines (limit: 1500)'
+        );
+        expect(result.stdout).toContain(
+          'ERROR: ./src/legacy.cjs has 1600 lines (limit: 1500)'
+        );
+        expect(result.stdout).toContain(
+          'The following files exceed the 1500 line limit:'
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('fails Markdown files over the hard limit', () => {
+      const root = createFixture({
+        'docs/HUGE.md': 1501,
+      });
+
+      try {
+        const result = runLineLimitCheck(root);
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain(
+          'ERROR: ./docs/HUGE.md has 1501 lines (limit: 1500)'
+        );
+        expect(result.stdout).toContain(
+          'The following files exceed the 1500 line limit:'
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('exempts case-study generated-data files from the limit', () => {
+      const root = createFixture({
+        'docs/case-studies/issue-99/data/raw.md': 5000,
+        'docs/case-studies/issue-99/data/sample.cjs': 5000,
+      });
+
+      try {
+        const result = runLineLimitCheck(root);
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).not.toContain(
+          'The following files exceed the 1500 line limit:'
+        );
+        expect(result.stdout).not.toContain('data/raw.md');
+        expect(result.stdout).not.toContain('data/sample.cjs');
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
     it('normalizes padded wc output from BSD-like environments', () => {
       const root = createFixture({
         'src/near-limit.mjs': 1351,


### PR DESCRIPTION
## Summary

Closes #67. The template's line-limit CI gate did not fully enforce the documented 1500-line architecture limit:

- `scripts/check-file-line-limits.sh` only checked `.mjs` files and `release.yml`, missing `.js` and `.cjs` files.
- ESLint covers the source files it lints, but the shell gate did not catch other JavaScript or Markdown files.
- Documentation validation used a 2500-line Markdown limit instead of the 1500-line architecture limit.

## Changes

- **`scripts/check-file-line-limits.sh`** now scans all JavaScript (`.js`, `.mjs`, `.cjs`) **and** Markdown (`.md`) files at the 1500-line limit. Case-study generated-data under `docs/case-studies/*/data/` is exempt and called out explicitly (the same paths are ignored by `eslint.config.js`).
- **Single source of truth**: the `check-file-line-limits` job now also triggers on documentation changes, and the redundant inline 2500-line doc-size check is removed from the `validate-docs` job (which keeps the required-files check).
- **`scripts/detect-code-changes.mjs`** now recognizes `.cjs` files so changes to them trigger the gate.
- **Docs** (`README.md`, `docs/BEST-PRACTICES.md`) updated to reflect the broadened coverage and the 1500-line documentation limit.
- **Changeset** added (`patch`).

## Reproduce / Verify

Before: a 1600-line `.js`/`.cjs`/`.md` file passed the gate; docs were allowed up to 2500 lines.

After:

```
bash scripts/check-file-line-limits.sh   # walks .js/.mjs/.cjs/.md + release.yml at 1500
```

## Tests

`tests/check-file-line-limits.test.js` adds cases that:
- fail `.js` and `.cjs` files over the limit,
- fail Markdown files over the limit,
- exempt case-study `*/data/*` files from the limit.

```
$ npm test
# tests 67 / pass 67 / fail 0
```

`npm run lint` and `npm run format:check` both pass.
