### PR TITLE
fix: run preview regen in Playwright container

### DIFF
--- a/.changeset/playwright-preview-container.md
+++ b/.changeset/playwright-preview-container.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Run the preview screenshot regeneration workflow inside the official Playwright container to avoid stalled Chromium downloads in CI.

--- a/.changeset/playwright-preview-container.md
+++ b/.changeset/playwright-preview-container.md
@@ -2,4 +2,4 @@
 '@link-foundation/example-package-name': patch
 ---
 
-Run the preview screenshot regeneration workflow inside the official Playwright container to avoid stalled Chromium downloads in CI.
+Run the preview screenshot regeneration workflow inside the official Playwright container to avoid stalled Chromium downloads in CI, and wait for desktop package output before uploading artifacts.

--- a/.changeset/playwright-preview-container.md
+++ b/.changeset/playwright-preview-container.md
@@ -2,4 +2,4 @@
 '@link-foundation/example-package-name': patch
 ---
 
-Run the preview screenshot regeneration workflow inside the official Playwright container to avoid stalled Chromium downloads in CI, and wait for desktop package output before uploading artifacts.
+Run the preview screenshot regeneration workflow inside the official Playwright container to avoid stalled Chromium downloads in CI, and keep the desktop packaging job on Node 20 while verifying package output before artifact upload.

--- a/.github/workflows/example-app.yml
+++ b/.github/workflows/example-app.yml
@@ -197,12 +197,17 @@ jobs:
   preview-regen:
     name: Regenerate Preview Images
     runs-on: ubuntu-latest
+    container:
+      # Keep this tag in sync with the playwright package version below.
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
     timeout-minutes: 20
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
     steps:
       - uses: actions/checkout@v6
         with:
@@ -212,11 +217,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24.x'
-
       - name: Install example app dependencies
         run: npm ci --prefix examples/universal-app
 
@@ -224,9 +224,6 @@ jobs:
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
         run: npm install --no-save --package-lock=false --no-audit --no-fund browser-commander@0.8.1 playwright@1.59.1
-
-      - name: Install Chromium for preview rendering
-        run: npx playwright install --with-deps chromium
 
       - name: Regenerate preview images
         run: node scripts/update-preview-images.mjs

--- a/.github/workflows/example-app.yml
+++ b/.github/workflows/example-app.yml
@@ -114,7 +114,19 @@ jobs:
         run: npm ci --prefix examples/universal-app
 
       - name: Package Electron app
-        run: npm run example:desktop:package
+        shell: bash
+        run: |
+          npm run example:desktop:package
+          for attempt in {1..30}; do
+            if [[ -d examples/universal-app/out ]] &&
+              [[ -n "$(find examples/universal-app/out -mindepth 1 -print -quit)" ]]; then
+              find examples/universal-app/out -maxdepth 2 -mindepth 1 -print
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Desktop package output was not created at examples/universal-app/out"
+          exit 1
         env:
           VITE_REPOSITORY_URL: https://github.com/${{ github.repository }}
 

--- a/.github/workflows/example-app.yml
+++ b/.github/workflows/example-app.yml
@@ -106,7 +106,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.x'
+          # Electron Forge packaging currently exits before writing out/ under
+          # Node 24 in CI. Use the package's supported Node 20 floor here until
+          # the desktop packaging toolchain is compatible with Node 24.
+          node-version: '20.x'
           cache: npm
           cache-dependency-path: examples/universal-app/package-lock.json
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-12T15:18:09.847Z for PR creation at branch issue-58-4fd60491b94f for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/58
-# Updated: 2026-05-12T22:59:25.452Z
-# Updated: 2026-05-15T07:39:21.510Z
-# Updated: 2026-05-29T22:30:31.279Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-12T15:18:09.847Z for PR creation at branch issue-58-4fd60491b94f for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/58
 # Updated: 2026-05-12T22:59:25.452Z
 # Updated: 2026-05-15T07:39:21.510Z
+# Updated: 2026-05-29T22:30:31.279Z

--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ Playwright and writes fresh screenshots to
 `docs/screenshots/example-app/example-app-{locale}-{theme}.png` on every
 push to `main` (and on `workflow_dispatch`). Any drift is committed back to
 `main` with `[skip ci]` so README/site images never go stale between
-releases.
+releases. The job runs in the official Playwright container with the browser
+already installed, avoiding CI stalls from live Chromium downloads.
 
 The same script is available locally:
 

--- a/tests/universal-app.test.js
+++ b/tests/universal-app.test.js
@@ -115,8 +115,11 @@ describe('universal React example app', () => {
     expect(existsSync('scripts/update-preview-images.mjs')).toBe(true);
 
     expect(workflow).toContain('preview-regen:');
+    expect(workflow).toContain(
+      'image: mcr.microsoft.com/playwright:v1.59.1-noble'
+    );
     expect(workflow).toContain('browser-commander');
-    expect(workflow).toContain('npx playwright install --with-deps chromium');
+    expect(workflow).not.toContain('npx playwright install');
     expect(workflow).toContain('node scripts/update-preview-images.mjs');
     expect(workflow).toContain('[skip ci]');
 

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -81,4 +81,30 @@ describe('workflow reliability policy', () => {
     expect(previewRegenJob).not.toContain('npx playwright install');
     expect(previewRegenJob).not.toContain('~/.cache/ms-playwright');
   });
+
+  it('verifies desktop package output before uploading artifacts', () => {
+    const exampleAppWorkflow = readWorkflow(
+      '.github/workflows/example-app.yml'
+    );
+    const desktopPackageJob = getJobBlock(
+      exampleAppWorkflow,
+      'desktop-package'
+    );
+    const packageStepIndex = desktopPackageJob.indexOf(
+      'name: Package Electron app'
+    );
+    const uploadStepIndex = desktopPackageJob.indexOf(
+      'name: Upload desktop package'
+    );
+
+    expect(packageStepIndex).toBeGreaterThanOrEqual(0);
+    expect(uploadStepIndex).toBeGreaterThan(packageStepIndex);
+    expect(desktopPackageJob).toContain('shell: bash');
+    expect(desktopPackageJob).toContain('npm run example:desktop:package');
+    expect(desktopPackageJob).toContain('find examples/universal-app/out');
+    expect(desktopPackageJob).toContain(
+      'Desktop package output was not created at examples/universal-app/out'
+    );
+    expect(desktopPackageJob).toContain('if-no-files-found: error');
+  });
 });

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -99,6 +99,8 @@ describe('workflow reliability policy', () => {
 
     expect(packageStepIndex).toBeGreaterThanOrEqual(0);
     expect(uploadStepIndex).toBeGreaterThan(packageStepIndex);
+    expect(desktopPackageJob).toContain("node-version: '20.x'");
+    expect(desktopPackageJob).not.toContain("node-version: '24.x'");
     expect(desktopPackageJob).toContain('shell: bash');
     expect(desktopPackageJob).toContain('npm run example:desktop:package');
     expect(desktopPackageJob).toContain('find examples/universal-app/out');

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -63,4 +63,22 @@ describe('workflow reliability policy', () => {
     expect(previewRegenJob).toContain('retention-days: 7');
     expect(previewRegenJob).toContain('if-no-files-found: ignore');
   });
+
+  it('uses the official Playwright image for preview regeneration instead of downloading Chromium', () => {
+    const exampleAppWorkflow = readWorkflow(
+      '.github/workflows/example-app.yml'
+    );
+    const previewRegenJob = getJobBlock(exampleAppWorkflow, 'preview-regen');
+    const imageVersion = previewRegenJob.match(
+      /image:\s*mcr\.microsoft\.com\/playwright:v([0-9.]+)-noble/
+    )?.[1];
+    const packageVersion = previewRegenJob.match(/playwright@([0-9.]+)/)?.[1];
+
+    expect(previewRegenJob).toContain('container:');
+    expect(imageVersion).toBe('1.59.1');
+    expect(packageVersion).toBe(imageVersion);
+    expect(previewRegenJob).toContain("PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'");
+    expect(previewRegenJob).not.toContain('npx playwright install');
+    expect(previewRegenJob).not.toContain('~/.cache/ms-playwright');
+  });
 });


### PR DESCRIPTION
Fixes #69

## Summary
- Run `preview-regen` in `mcr.microsoft.com/playwright:v1.59.1-noble`, with the image tag kept in sync with `playwright@1.59.1`.
- Set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`, use `/ms-playwright`, and remove the live `npx playwright install --with-deps chromium` step.
- Add workflow regression coverage plus documentation and a patch changeset for the container-based browser setup.
- Keep desktop packaging on Node 20.x and verify `examples/universal-app/out` exists before artifact upload, after CI and a local Node 24 reproduction showed Electron Forge can finish without writing package output.

## Reproduction
- The focused workflow test initially failed because `preview-regen` still installed Chromium during CI.
- CI run `26665690697` showed the desktop artifact upload failing because `examples/universal-app/out` did not exist.
- CI run `26665871646` plus a local `node@24` reproduction showed Electron Forge reaching package finalization without creating `out`; the same package command under Node 20 produced the expected output.

## Tests
- `node --test --test-timeout=30000 tests/workflow-reliability.test.js tests/universal-app.test.js`
- `npm test`
- `npm run check`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `GITHUB_BASE_REF=main GITHUB_BASE_SHA=$(git rev-parse origin/main) GITHUB_HEAD_SHA=$(git rev-parse HEAD) node scripts/validate-changeset.mjs`
- `git diff --check`
- `npm run example:desktop:package` under Node 20
- CI passed: `Example app` run `26666086104`, `Checks and release` run `26666086079`, and `Broken Link Checker` run `26666086069`.
