### PR TITLE
fix: Cap generated GitHub release notes

### DIFF
--- a/.changeset/short-release-notes.md
+++ b/.changeset/short-release-notes.md
@@ -1,0 +1,7 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Cap generated GitHub release notes before creating releases so oversized changelog
+entries link to the full tagged changelog instead of failing GitHub API
+validation.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-04T17:16:24.647Z for PR creation at branch issue-71-aa26a2d9b106 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/71

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-04T17:16:24.647Z for PR creation at branch issue-71-aa26a2d9b106 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/71

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -17,6 +17,10 @@ import { fileURLToPath } from 'node:url';
 const USAGE =
   'Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>]';
 
+// Keep comfortably below GitHub's observed 125000-character release body limit.
+export const GITHUB_RELEASE_BODY_MAX_BYTES = 120_000;
+const textEncoder = new globalThis.TextEncoder();
+
 export function parseArgs(argv, env = process.env) {
   const config = {
     language: env.LANGUAGE ?? 'JavaScript',
@@ -104,11 +108,80 @@ export function buildReleaseTitle(language, releaseVersion) {
   return `[${titleLanguage}] ${normalizeReleaseVersionForTitle(releaseVersion)}`;
 }
 
-export function buildReleasePayload({ changelog, language, tag, version }) {
+function getUtf8ByteLength(value) {
+  return textEncoder.encode(value).byteLength;
+}
+
+function truncateToUtf8Bytes(value, maxBytes) {
+  const chunks = [];
+  let usedBytes = 0;
+
+  for (const character of value) {
+    const characterBytes = getUtf8ByteLength(character);
+
+    if (usedBytes + characterBytes > maxBytes) {
+      break;
+    }
+
+    chunks.push(character);
+    usedBytes += characterBytes;
+  }
+
+  return chunks.join('');
+}
+
+function buildTaggedChangelogUrl(repository, tag) {
+  return `https://github.com/${repository}/blob/${tag}/CHANGELOG.md`;
+}
+
+function buildTruncatedReleaseNotesNotice({ repository, tag }) {
+  const changelogUrl = buildTaggedChangelogUrl(repository, tag);
+
+  return `Release notes were shortened to fit GitHub's release body limit. See the full tagged CHANGELOG.md: ${changelogUrl}`;
+}
+
+export function limitReleaseNotesBytes({
+  maxBytes = GITHUB_RELEASE_BODY_MAX_BYTES,
+  releaseNotes,
+  repository,
+  tag,
+}) {
+  if (getUtf8ByteLength(releaseNotes) <= maxBytes) {
+    return releaseNotes;
+  }
+
+  const suffix = `\n\n...\n\n${buildTruncatedReleaseNotesNotice({
+    repository,
+    tag,
+  })}`;
+  const suffixBytes = getUtf8ByteLength(suffix);
+  const availableBytes = Math.max(0, maxBytes - suffixBytes);
+  const shortenedNotes = truncateToUtf8Bytes(
+    releaseNotes,
+    availableBytes
+  ).trimEnd();
+  const limitedNotes = `${shortenedNotes}${suffix}`;
+
+  if (getUtf8ByteLength(limitedNotes) <= maxBytes) {
+    return limitedNotes;
+  }
+
+  return truncateToUtf8Bytes(limitedNotes, maxBytes);
+}
+
+export function buildReleasePayload({
+  changelog,
+  language,
+  repository,
+  tag,
+  version,
+}) {
+  const releaseNotes = extractReleaseNotes(changelog, version);
+
   return JSON.stringify({
     tag_name: tag,
     name: buildReleaseTitle(language ?? 'JavaScript', tag),
-    body: extractReleaseNotes(changelog, version),
+    body: limitReleaseNotesBytes({ releaseNotes, repository, tag }),
   });
 }
 
@@ -188,7 +261,13 @@ export function main({
     stdout(`Creating GitHub release for ${tag}...`);
 
     const changelog = readFileSync(path.join(cwd, 'CHANGELOG.md'), 'utf8');
-    const payload = buildReleasePayload({ changelog, language, tag, version });
+    const payload = buildReleasePayload({
+      changelog,
+      language,
+      repository,
+      tag,
+      version,
+    });
     const result = createRelease({ payload, repository, spawn });
 
     if (result.alreadyExists) {

--- a/tests/create-github-release.test.js
+++ b/tests/create-github-release.test.js
@@ -21,6 +21,7 @@ import { fileURLToPath, URL } from 'node:url';
 import {
   buildReleasePayload,
   createRelease,
+  GITHUB_RELEASE_BODY_MAX_BYTES,
   parseArgs,
 } from '../scripts/create-github-release.mjs';
 
@@ -36,6 +37,7 @@ const isNodeRuntime =
   !isBunRuntime &&
   !isDenoRuntime;
 const isWindowsNodeRuntime = isNodeRuntime && process.platform === 'win32';
+const textEncoder = new globalThis.TextEncoder();
 // Node on Windows does not execute the .cmd gh fixture through spawnSync.
 // The injected-spawn tests below cover release result handling on that runner.
 const canRunCliFixtures =
@@ -185,6 +187,10 @@ function createSpawnRecorder(result) {
   };
 }
 
+function getUtf8ByteLength(value) {
+  return textEncoder.encode(value).byteLength;
+}
+
 describe('create-github-release release title formatting', () => {
   it('parses language from CLI arguments and environment defaults', () => {
     expect(parseArgs([], {})).toEqual({
@@ -235,6 +241,43 @@ describe('create-github-release release title formatting', () => {
       name: '[JavaScript] 1.2.3',
       body: '- Fix release creation',
     });
+  });
+
+  it('caps oversized release notes and links to the tagged changelog', () => {
+    const multibyteCharacter = '\u{1f680}';
+    const largeEntry = `- ${multibyteCharacter.repeat(
+      GITHUB_RELEASE_BODY_MAX_BYTES / 2
+    )}`;
+    const changelog = `# Changelog
+
+## 1.2.3
+
+${largeEntry}
+
+## 1.2.2
+
+- Previous release
+`;
+
+    const payload = JSON.parse(
+      buildReleasePayload({
+        changelog,
+        language: 'JavaScript',
+        repository: 'owner/repo',
+        tag: 'v1.2.3',
+        version: '1.2.3',
+      })
+    );
+
+    expect(getUtf8ByteLength(payload.body)).toBeLessThanOrEqual(
+      GITHUB_RELEASE_BODY_MAX_BYTES
+    );
+    expect(
+      payload.body.startsWith(`- ${multibyteCharacter}${multibyteCharacter}`)
+    ).toBe(true);
+    expect(payload.body).toContain(
+      'https://github.com/owner/repo/blob/v1.2.3/CHANGELOG.md'
+    );
   });
 });
 


### PR DESCRIPTION
Fixes #71

## Summary

- Add a conservative `120000` byte guard before `scripts/create-github-release.mjs` sends release notes to `gh api`.
- Preserve the beginning of oversized changelog entries and append a note pointing to the full tagged `CHANGELOG.md`.
- Add regression coverage with a multibyte oversized changelog entry so the test verifies UTF-8 byte length, not just character count.
- Add a patch changeset for the release pipeline fix.

## Reproduction

Before the fix, `buildReleasePayload` passed the entire extracted changelog section through as the GitHub Release API `body`. The new regression test creates a release entry larger than the guard limit and verifies the generated body is capped, starts with the original notes, and includes `https://github.com/owner/repo/blob/v1.2.3/CHANGELOG.md`.

## Tests

- `node --test tests/create-github-release.test.js`
- `npm test`
- `npm run check`
- `bun test --timeout 30000`
- `deno test --allow-read`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `git diff --check`
