### PR TITLE
ci: add concurrency block to links.yml

### DIFF
--- a/.changeset/links-concurrency.md
+++ b/.changeset/links-concurrency.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Add a `concurrency` block to the Broken Link Checker workflow (`links.yml`) so redundant runs are cancelled on new commits, consistent with the other workflows in the template.

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,6 +16,15 @@ on:
       - '.github/workflows/links.yml'
   workflow_dispatch:
 
+# Concurrency: Only one workflow run per branch at a time
+# - For main branch: let runs finish so a newer push does not cancel an
+#   in-flight link check.
+# - For PR branches: cancel older runs so new pushes supersede stale checks.
+# See: docs/case-studies/issue-25/DETAILED-COMPARISON.md for context
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   link-checker:
     name: Check Links

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-10T00:33:14.952Z for PR creation at branch issue-73-e14d5ef8be31 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/73

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -26,6 +26,7 @@ describe('workflow reliability policy', () => {
     const workflowPaths = [
       '.github/workflows/example-app.yml',
       '.github/workflows/release.yml',
+      '.github/workflows/links.yml',
     ];
 
     for (const workflowPath of workflowPaths) {


### PR DESCRIPTION
## Summary

`.github/workflows/links.yml` (Broken Link Checker) was the only workflow in this template missing a `concurrency:` block. Because it triggers on `push` (main) and `pull_request` like its siblings, pushing multiple commits in quick succession left redundant link-check runs in flight instead of cancelling superseded ones — wasting CI minutes.

This adds the same `concurrency` block already used by `release.yml` and `example-app.yml`, placed immediately after the `on:` section:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

The `github.ref != 'refs/heads/main'` guard keeps the main-branch run from being cancelled mid-flight while still cancelling redundant PR/branch runs — consistent with the rest of the template.

Fixes #73

## Changes

- `.github/workflows/links.yml` — added the `concurrency` block (with explanatory comment matching the sibling workflows).
- `tests/workflow-reliability.test.js` — added `links.yml` to the existing concurrency-policy test so this is covered as a regression guard.
- `.changeset/links-concurrency.md` — patch changeset for the next release.

## Verification

- The concurrency-policy test fails on `links.yml` **without** the fix (`# pass 3 / # fail 1`) and passes **with** it (`# pass 4 / # fail 0`), confirming it's a genuine regression test.
- `npm run lint`, `npm run format:check`, and the file line-limit check all pass.
