### PR TITLE
fix(publish): classify non-retryable npm failures and add NPM_TOKEN first-publish bootstrap

### DIFF
--- a/.changeset/fix-publish-non-retryable-and-token-bootstrap.md
+++ b/.changeset/fix-publish-non-retryable-and-token-bootstrap.md
@@ -1,0 +1,14 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Fix npm release path for brand-new packages (issue #77):
+
+- `publish-to-npm.mjs` now classifies authentication / registry-configuration
+  failures (404/401/403, `access token expired`, `ENEEDAUTH`, etc.) as
+  non-retryable and fails fast with actionable guidance instead of retrying
+  `MAX_RETRIES` times and hiding the real cause behind a generic error.
+- The `release` and `instant-release` publish steps now pass an optional
+  `NODE_AUTH_TOKEN` sourced from `secrets.NPM_TOKEN`, providing a first-publish
+  bootstrap path. OIDC trusted publishing remains the steady-state mechanism;
+  the token is only needed for the very first release of a new package.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,6 +427,15 @@ jobs:
           steps.version.outputs.already_released == 'true' ||
           (steps.check_release.outputs.should_release == 'true' && steps.check_release.outputs.skip_bump == 'true')
         id: publish
+        # Optional NPM_TOKEN bootstrap fallback. OIDC trusted publishing is the
+        # steady-state mechanism, but it cannot create a brand-new package (the
+        # first publish returns E404 because a trusted publisher can only be
+        # configured for a package that already exists). When NPM_TOKEN is set,
+        # the first publish succeeds; once the package exists and a trusted
+        # publisher is configured, OIDC takes over and the token can be removed.
+        # See issue #77.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node scripts/publish-to-npm.mjs --should-pull
 
       - name: Create GitHub Release
@@ -483,6 +492,10 @@ jobs:
         # Run if version was committed OR if a previous attempt already committed (for re-runs)
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         id: publish
+        # Optional NPM_TOKEN bootstrap fallback; OIDC trusted publishing is used
+        # when the secret is unset. See the release job above for details (#77).
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node scripts/publish-to-npm.mjs
 
       - name: Create GitHub Release

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-10T00:33:14.952Z for PR creation at branch issue-73-e14d5ef8be31 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/73
 # Updated: 2026-06-13T08:49:54.641Z
+# Updated: 2026-06-13T11:17:32.913Z

--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ The release workflow uses [Changesets](https://github.com/changesets/changesets)
 5. **Optional Docker Hub publishing**: When configured, waits for the exact npm version and tags the Docker image with that version
 6. **GitHub releases**: Auto-created with formatted release notes
 
+> **First release of a brand-new package**: OIDC trusted publishing cannot
+> create a package that does not exist yet (the first publish fails with
+> `E404`, because a trusted publisher can only be configured for an existing
+> package). To bootstrap, add a repository secret named `NPM_TOKEN` (a
+> granular/automation token with publish access). The release workflow passes
+> it as `NODE_AUTH_TOKEN` automatically. Once the package exists and OIDC
+> trusted publishing is configured on npmjs.com, the token becomes optional and
+> can be removed.
+
 #### Manual Releases
 
 Two manual release modes are available via GitHub Actions:

--- a/scripts/publish-failure-classifier.mjs
+++ b/scripts/publish-failure-classifier.mjs
@@ -1,0 +1,77 @@
+/**
+ * Classify npm publish failures and build actionable guidance.
+ *
+ * Some publish failures are permanent: retrying a 404/401/403 (or any auth /
+ * registry-configuration error) produces the same error every time and only
+ * delays a clear, actionable message. The most common case is the FIRST publish
+ * of a brand-new package via npm OIDC trusted publishing, which returns E404
+ * because npm cannot bootstrap a new package with trusted publishing alone — a
+ * trusted publisher can only be configured for a package that already exists.
+ *
+ * Addresses issue:
+ * - link-foundation/js-ai-driven-development-pipeline-template#77
+ */
+
+// Failures caused by authentication / registry configuration. Retrying these is
+// pointless and only hides the real cause behind a generic
+// "Failed to publish after N attempts" message.
+export const NON_RETRYABLE_PATTERNS = [
+  'npm error 404',
+  'npm error 401',
+  'npm error 403',
+  'e404',
+  'e401',
+  'e403',
+  'access token expired',
+  'eneedauth',
+  'you must be logged in',
+  'unable to authenticate',
+];
+
+/**
+ * Determine whether a detected failure is caused by authentication / registry
+ * configuration (and therefore should not be retried).
+ * @param {string} output - Combined stdout and stderr (and/or error message)
+ * @returns {boolean}
+ */
+export function isNonRetryableFailure(output) {
+  const lowerOutput = String(output || '').toLowerCase();
+  return NON_RETRYABLE_PATTERNS.some((pattern) =>
+    lowerOutput.includes(pattern)
+  );
+}
+
+/**
+ * Build an actionable, human-readable explanation for an authentication /
+ * registry-configuration publish failure (most commonly an E404 on the very
+ * first publish of a brand-new package via OIDC trusted publishing).
+ * @param {string} packageName - The package that failed to publish
+ * @returns {string}
+ */
+export function buildAuthFailureGuidance(packageName) {
+  return [
+    '',
+    '=== NPM PUBLISH AUTHENTICATION / REGISTRY FAILURE ===',
+    '',
+    `Failed to publish ${packageName}. This is an authentication or registry`,
+    'configuration error, not a transient one, so it was not retried.',
+    '',
+    'Most common cause: the FIRST publish of a brand-new package via npm OIDC',
+    'trusted publishing returns "E404 Not Found - PUT". npm cannot bootstrap a',
+    'new package with trusted publishing alone, because a trusted publisher can',
+    'only be configured for a package that already exists on the registry.',
+    '',
+    'SOLUTION (choose one):',
+    '  1. Bootstrap the first release with a classic automation token:',
+    '     - Create a granular/automation token on npmjs.com with publish access.',
+    '     - Add it as the repository secret NPM_TOKEN.',
+    '     - The release workflow passes it as NODE_AUTH_TOKEN automatically, so',
+    '       the next run will publish the initial version.',
+    '  2. After the package exists, configure OIDC trusted publishing on',
+    '     npmjs.com (Package settings -> Trusted publishing) so future releases',
+    '     need no token at all. The NPM_TOKEN secret then becomes optional.',
+    '',
+    'See: https://docs.npmjs.com/trusted-publishers',
+    '',
+  ].join('\n');
+}

--- a/scripts/publish-to-npm.mjs
+++ b/scripts/publish-to-npm.mjs
@@ -24,6 +24,10 @@ import { appendFileSync } from 'fs';
 
 import { getJsRoot, needsCd, parseJsRootConfig } from './js-paths.mjs';
 import { formatNpmPackageVersion, readPackageInfo } from './package-info.mjs';
+import {
+  buildAuthFailureGuidance,
+  isNonRetryableFailure,
+} from './publish-failure-classifier.mjs';
 
 // Load use-m dynamically
 const { use } = eval(
@@ -226,6 +230,17 @@ async function attemptPublish(
   const analysisError = analyzePublishResult(result, error);
 
   if (analysisError) {
+    // Mark authentication / registry-configuration failures as non-retryable so
+    // the retry loop can fail fast with actionable guidance instead of burning
+    // through MAX_RETRIES (issue #77).
+    const combinedOutput = [
+      analysisError.message || '',
+      result?.stdout || '',
+      result?.stderr || '',
+    ].join('\n');
+    if (isNonRetryableFailure(combinedOutput)) {
+      analysisError.nonRetryable = true;
+    }
     return { success: false, error: analysisError };
   }
 
@@ -302,6 +317,16 @@ async function main() {
         setOutput('published_version', currentVersion);
         console.log(`\u2705 Published ${packageName}@${currentVersion} to npm`);
         return;
+      }
+
+      // Authentication / registry-configuration errors will not be fixed by
+      // retrying, so fail fast with actionable guidance instead of burning
+      // through MAX_RETRIES (which previously hid the real cause behind a
+      // generic "Failed to publish after 3 attempts" message). See issue #77.
+      if (error?.nonRetryable) {
+        console.error(`Publish failed: ${error.message}`);
+        console.error(buildAuthFailureGuidance(packageName));
+        process.exit(1);
       }
 
       if (i < MAX_RETRIES) {

--- a/tests/publish-failure-classifier.test.js
+++ b/tests/publish-failure-classifier.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'test-anywhere';
+
+import {
+  NON_RETRYABLE_PATTERNS,
+  buildAuthFailureGuidance,
+  isNonRetryableFailure,
+} from '../scripts/publish-failure-classifier.mjs';
+
+describe('publish failure classifier', () => {
+  it('classifies a first-publish E404 as non-retryable', () => {
+    const output = [
+      'npm error code E404',
+      'npm error 404 Not Found - PUT https://registry.npmjs.org/@scope%2fpkg',
+      "The requested resource '@scope/pkg@0.8.1' could not be found",
+    ].join('\n');
+
+    expect(isNonRetryableFailure(output)).toBe(true);
+  });
+
+  it('classifies authentication failures (401/403/auth) as non-retryable', () => {
+    expect(isNonRetryableFailure('npm error 401 Unauthorized')).toBe(true);
+    expect(isNonRetryableFailure('npm error 403 Forbidden')).toBe(true);
+    expect(isNonRetryableFailure('npm error code E401')).toBe(true);
+    expect(isNonRetryableFailure('npm error code E403')).toBe(true);
+    expect(isNonRetryableFailure('Access token expired')).toBe(true);
+    expect(isNonRetryableFailure('npm ERR! need auth ENEEDAUTH')).toBe(true);
+    expect(
+      isNonRetryableFailure('You must be logged in to publish packages')
+    ).toBe(true);
+    expect(isNonRetryableFailure('Unable to authenticate, your token')).toBe(
+      true
+    );
+  });
+
+  it('is case-insensitive when matching patterns', () => {
+    expect(isNonRetryableFailure('NPM ERROR 404 NOT FOUND')).toBe(true);
+    expect(isNonRetryableFailure('ACCESS TOKEN EXPIRED')).toBe(true);
+  });
+
+  it('treats transient/unknown failures as retryable', () => {
+    expect(isNonRetryableFailure('')).toBe(false);
+    expect(isNonRetryableFailure('ETIMEDOUT request to registry')).toBe(false);
+    expect(isNonRetryableFailure('npm error code ECONNRESET')).toBe(false);
+    expect(
+      isNonRetryableFailure('Package not found on npm after publish attempt')
+    ).toBe(false);
+  });
+
+  it('handles null/undefined input without throwing', () => {
+    expect(isNonRetryableFailure(null)).toBe(false);
+    expect(isNonRetryableFailure(undefined)).toBe(false);
+  });
+
+  it('exposes the documented non-retryable patterns', () => {
+    for (const pattern of [
+      'npm error 404',
+      'npm error 401',
+      'npm error 403',
+      'e404',
+      'e401',
+      'e403',
+      'access token expired',
+      'eneedauth',
+      'you must be logged in',
+      'unable to authenticate',
+    ]) {
+      expect(NON_RETRYABLE_PATTERNS).toContain(pattern);
+    }
+  });
+
+  it('builds actionable guidance naming the package and the bootstrap token', () => {
+    const guidance = buildAuthFailureGuidance('@scope/pkg');
+
+    expect(guidance).toContain('@scope/pkg');
+    expect(guidance).toContain('NPM_TOKEN');
+    expect(guidance).toContain('NODE_AUTH_TOKEN');
+    expect(guidance.toLowerCase()).toContain('trusted publish');
+    expect(guidance).toContain('https://docs.npmjs.com/trusted-publishers');
+  });
+});

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -111,3 +111,19 @@ describe('workflow reliability policy', () => {
     expect(desktopPackageJob).toContain('if-no-files-found: error');
   });
 });
+
+describe('npm publish token bootstrap (issue #77)', () => {
+  // The first publish of a brand-new package cannot use OIDC trusted publishing
+  // (npm returns E404 because a trusted publisher can only be configured for an
+  // existing package). Every Publish-to-npm step must therefore expose an
+  // optional NODE_AUTH_TOKEN fallback sourced from secrets.NPM_TOKEN.
+  for (const jobName of ['release', 'instant-release']) {
+    it(`passes secrets.NPM_TOKEN as NODE_AUTH_TOKEN on the ${jobName} publish step`, () => {
+      const workflow = readWorkflow('.github/workflows/release.yml');
+      const job = getJobBlock(workflow, jobName);
+
+      expect(job).toContain('node scripts/publish-to-npm.mjs');
+      expect(job).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #77 — the npm release path failed slowly and unclearly on the **first
release of a brand-new package**, with two related root causes.

### Problem 1 — Permanent failures were retried `MAX_RETRIES` times

`scripts/publish-to-npm.mjs` treated every detected failure as retryable. But
`E404` (first publish of a package that does not exist yet),
`401`/`403`/`ENEEDAUTH`/`Access token expired` are **permanent** — retrying
wastes ~28s and hides the real cause behind a generic
`❌ Failed to publish after 3 attempts`.

**Fix:** A new `scripts/publish-failure-classifier.mjs` exposes
`isNonRetryableFailure()` and `buildAuthFailureGuidance()`. When a publish error
matches a non-retryable pattern, `attemptPublish()` flags it and the retry loop
**fails fast** with an actionable message explaining the first-publish
bootstrap, instead of retrying.

### Problem 2 — No first-publish bootstrap path (OIDC cannot create a new package)

npm trusted publishing requires a *trusted publisher* configured on npmjs.com,
which can only be done for a package that **already exists**. The first publish
of a brand-new package therefore cannot use OIDC and fails with `E404`.

**Fix:** Both `Publish to npm` steps (the `release` and `instant-release` jobs)
now pass an optional `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`. When
`NPM_TOKEN` is set, the first publish succeeds; once the package exists and a
trusted publisher is configured, OIDC takes over and the token can be removed.
Documented in `README.md`.

## How to reproduce the original issue

Run the release workflow for a scoped package that has never been published and
without a configured trusted publisher / token — npm returns `E404` and the old
script retried 3× before failing with a generic message.

## Tests

- `tests/publish-failure-classifier.test.js` — asserts E404/401/403/auth output
  is classified non-retryable, transient errors stay retryable, matching is
  case-insensitive and null-safe, and the guidance names the package +
  `NPM_TOKEN`/`NODE_AUTH_TOKEN`.
- `tests/workflow-reliability.test.js` — asserts both publish steps pass
  `secrets.NPM_TOKEN` as `NODE_AUTH_TOKEN`.

All 84 tests pass locally (`npm test`); lint, format, and duplication checks are
clean.
