### PR TITLE
CI: skip test matrix for non-code PR changes

### DIFF
--- a/.changeset/ci-test-change-gate.md
+++ b/.changeset/ci-test-change-gate.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Skip the slow CI test matrix for pull requests that only touch non-code files.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,10 +246,19 @@ jobs:
         check-file-line-limits,
       ]
     # Use !cancelled() instead of always() so cancellation propagates correctly (hive-mind issue #1278)
-    # Run if: push event, OR changeset-check succeeded, OR changeset-check was skipped (docs-only PR)
-    # AND all fast checks passed (or were skipped for irrelevant changes)
+    # Run on pushes, or PRs with code/package/workflow changes that can affect
+    # test results. Skipped fast checks still count as non-failures only after
+    # this positive change-detector gate passes.
     if: |
       !cancelled() &&
+      (
+        github.event_name == 'push' ||
+        needs.detect-changes.outputs.any-code-changed == 'true' ||
+        needs.detect-changes.outputs.mjs-changed == 'true' ||
+        needs.detect-changes.outputs.js-changed == 'true' ||
+        needs.detect-changes.outputs.package-changed == 'true' ||
+        needs.detect-changes.outputs.workflow-changed == 'true'
+      ) &&
       (github.event_name == 'push' || needs.changeset-check.result == 'success' || needs.changeset-check.result == 'skipped') &&
       (needs.test-compilation.result == 'success' || needs.test-compilation.result == 'skipped') &&
       (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-10T00:33:14.952Z for PR creation at branch issue-73-e14d5ef8be31 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/73
 # Updated: 2026-06-13T08:49:54.641Z
 # Updated: 2026-06-13T11:17:32.913Z
-# Updated: 2026-06-13T11:39:23.277Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-06-10T00:33:14.952Z for PR creation at branch issue-73-e14d5ef8be31 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/73
 # Updated: 2026-06-13T08:49:54.641Z
 # Updated: 2026-06-13T11:17:32.913Z
+# Updated: 2026-06-13T11:39:23.277Z

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -21,6 +21,72 @@ function getJobBlock(workflow, jobName) {
   return lines.slice(start, end === -1 ? lines.length : end).join('\n');
 }
 
+function getMultilineIfExpression(jobBlock) {
+  const lines = jobBlock.split('\n');
+  const start = lines.findIndex((line) => line === '    if: |');
+
+  if (start === -1) {
+    return '';
+  }
+
+  const expressionLines = [];
+
+  for (const line of lines.slice(start + 1)) {
+    if (/^[ ]{4}\S/.test(line)) {
+      break;
+    }
+
+    expressionLines.push(line.slice(6));
+  }
+
+  return expressionLines.join('\n').trim();
+}
+
+function evaluateWorkflowIf(expression, context) {
+  const javaScriptExpression = expression
+    .replaceAll('!cancelled()', '!context.cancelled')
+    .replaceAll('github.event_name', 'context.github.event_name')
+    .replace(
+      /needs\.([a-zA-Z0-9_-]+)\.outputs\.([a-zA-Z0-9_-]+)/g,
+      'context.needs["$1"].outputs["$2"]'
+    )
+    .replace(/needs\.([a-zA-Z0-9_-]+)\.result/g, 'context.needs["$1"].result');
+
+  return Function(
+    'context',
+    `"use strict"; return (${javaScriptExpression});`
+  )(context);
+}
+
+function createTestJobContext({
+  eventName = 'pull_request',
+  outputs = {},
+  result = 'skipped',
+} = {}) {
+  return {
+    cancelled: false,
+    github: {
+      event_name: eventName,
+    },
+    needs: {
+      'detect-changes': {
+        outputs: {
+          'any-code-changed': 'false',
+          'mjs-changed': 'false',
+          'js-changed': 'false',
+          'package-changed': 'false',
+          'workflow-changed': 'false',
+          ...outputs,
+        },
+      },
+      'changeset-check': { result },
+      'test-compilation': { result },
+      lint: { result },
+      'check-file-line-limits': { result },
+    },
+  };
+}
+
 describe('workflow reliability policy', () => {
   it('cancels superseded non-main runs without cancelling main runs', () => {
     const workflowPaths = [
@@ -109,6 +175,32 @@ describe('workflow reliability policy', () => {
       'Desktop package output was not created at examples/universal-app/out'
     );
     expect(desktopPackageJob).toContain('if-no-files-found: error');
+  });
+});
+
+describe('release workflow change gates', () => {
+  it('skips the slow test matrix for pull requests with no code changes', () => {
+    const workflow = readWorkflow('.github/workflows/release.yml');
+    const testJob = getJobBlock(workflow, 'test');
+    const testCondition = getMultilineIfExpression(testJob);
+    const nonCodePullRequest = createTestJobContext();
+
+    expect(evaluateWorkflowIf(testCondition, nonCodePullRequest)).toBe(false);
+  });
+
+  it('runs the slow test matrix for workflow changes after fast checks pass', () => {
+    const workflow = readWorkflow('.github/workflows/release.yml');
+    const testJob = getJobBlock(workflow, 'test');
+    const testCondition = getMultilineIfExpression(testJob);
+    const workflowPullRequest = createTestJobContext({
+      outputs: {
+        'any-code-changed': 'true',
+        'workflow-changed': 'true',
+      },
+      result: 'success',
+    });
+
+    expect(evaluateWorkflowIf(testCondition, workflowPullRequest)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a positive `detect-changes` gate to the release workflow `test` job
- keep existing fast-check result guards so failed prerequisites still block the matrix
- add regression coverage for non-code PR changes and workflow-change PRs
- add a patch changeset for the template behavior change

## Verification
- `npm test`
- `npm run check`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`
- `node scripts/check-version.mjs`

Fixes #79