### PR TITLE
ci: Add install-from-package npm smoke test

### DIFF
--- a/.changeset/smoke-test-published-package.md
+++ b/.changeset/smoke-test-published-package.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Add a post-publish smoke test that installs the just-published npm package in a clean project and verifies its entry points.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -447,6 +447,10 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node scripts/publish-to-npm.mjs --should-pull
 
+      - name: Smoke-test published npm package
+        if: steps.publish.outputs.published == 'true'
+        run: node scripts/smoke-test-package.mjs --package-version "${{ steps.publish.outputs.published_version }}"
+
       - name: Create GitHub Release
         if: steps.publish.outputs.published == 'true'
         env:
@@ -506,6 +510,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: node scripts/publish-to-npm.mjs
+
+      - name: Smoke-test published npm package
+        if: steps.publish.outputs.published == 'true'
+        run: node scripts/smoke-test-package.mjs --package-version "${{ steps.publish.outputs.published_version }}"
 
       - name: Create GitHub Release
         if: steps.publish.outputs.published == 'true'

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-06-10T00:33:14.952Z for PR creation at branch issue-73-e14d5ef8be31 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/73
 # Updated: 2026-06-13T08:49:54.641Z
 # Updated: 2026-06-13T11:17:32.913Z
+# Updated: 2026-06-14T10:32:26.430Z

--- a/scripts/smoke-test-package.mjs
+++ b/scripts/smoke-test-package.mjs
@@ -1,0 +1,541 @@
+#!/usr/bin/env node
+
+/**
+ * Install-from-package smoke test for published npm artifacts.
+ *
+ * This runs after publishing and verifies the package as a consumer sees it:
+ * from a clean temp project, installed from the npm registry, not from the
+ * repository checkout.
+ */
+
+import { execFileSync, spawn } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { formatNpmPackageVersion, readPackageInfo } from './package-info.mjs';
+
+const DEFAULT_CLI_ARGS = ['--help'];
+const DEFAULT_MAX_ATTEMPTS = 5;
+const DEFAULT_PREVIEW_LINES = 5;
+const DEFAULT_SERVER_TIMEOUT_SECONDS = 15;
+const DEFAULT_SLEEP_SECONDS = 10;
+const BOOLEAN_OPTIONS = new Set(['skip-cli', 'skip-library']);
+const USAGE =
+  'Usage: node scripts/smoke-test-package.mjs --package-version <version> [--package-name <name>] [--js-root <path>] [--max-attempts <count>] [--sleep-seconds <count>] [--cli-args <args>] [--skip-cli] [--skip-library] [--server-bin <bin>] [--server-args <args>] [--server-health-url <url>]';
+
+function parsePositiveInteger(value, optionName) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${optionName} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function readCliOptions(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+
+    const inlineValueIndex = arg.indexOf('=');
+    if (inlineValueIndex !== -1) {
+      options[arg.slice(2, inlineValueIndex)] = arg.slice(inlineValueIndex + 1);
+      continue;
+    }
+
+    const nextValue = argv[index + 1];
+    const optionName = arg.slice(2);
+    if (nextValue === undefined || nextValue.startsWith('--')) {
+      if (!BOOLEAN_OPTIONS.has(optionName)) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      options[optionName] = true;
+      continue;
+    }
+
+    options[optionName] = nextValue;
+    index++;
+  }
+
+  return options;
+}
+
+function parseBoolean(value) {
+  return value === true || value === 'true' || value === '1';
+}
+
+function readOption(cliOptions, env, cliName, envNames, fallback = '') {
+  if (Object.hasOwn(cliOptions, cliName)) {
+    return cliOptions[cliName];
+  }
+
+  for (const envName of envNames) {
+    if (env[envName] !== undefined && env[envName] !== '') {
+      return env[envName];
+    }
+  }
+
+  return fallback;
+}
+
+function readPositiveOption(cliOptions, env, cliName, envNames, fallback) {
+  return parsePositiveInteger(
+    readOption(cliOptions, env, cliName, envNames, String(fallback)),
+    `--${cliName}`
+  );
+}
+
+export function parseCommandArgs(value, fallback = []) {
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(String);
+  }
+
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return fallback;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) {
+      return parsed.map(String);
+    }
+  } catch {
+    // Fall back to simple whitespace splitting for CI env values.
+  }
+
+  return trimmed.split(/\s+/);
+}
+
+export function parseArgs(argv, env = process.env) {
+  const cliOptions = readCliOptions(argv);
+  const cliValue = (name, envNames, fallback) =>
+    readOption(cliOptions, env, name, envNames, fallback);
+  const positiveValue = (name, envNames, fallback) =>
+    readPositiveOption(cliOptions, env, name, envNames, fallback);
+
+  return {
+    cliArgs: parseCommandArgs(
+      cliValue('cli-args', ['SMOKE_TEST_CLI_ARGS']),
+      DEFAULT_CLI_ARGS
+    ),
+    jsRoot: cliValue('js-root', ['JS_ROOT']),
+    maxAttempts: positiveValue(
+      'max-attempts',
+      ['MAX_ATTEMPTS'],
+      DEFAULT_MAX_ATTEMPTS
+    ),
+    packageName: cliValue('package-name', ['PACKAGE_NAME']),
+    packageVersion: cliValue('package-version', ['PACKAGE_VERSION', 'VERSION']),
+    serverArgs: parseCommandArgs(
+      cliValue('server-args', ['SMOKE_TEST_SERVER_ARGS']),
+      []
+    ),
+    serverBin: cliValue('server-bin', ['SMOKE_TEST_SERVER_BIN']),
+    serverHealthUrl: cliValue('server-health-url', [
+      'SMOKE_TEST_SERVER_HEALTH_URL',
+    ]),
+    serverTimeoutSeconds: positiveValue(
+      'server-timeout-seconds',
+      ['SMOKE_TEST_SERVER_TIMEOUT_SECONDS'],
+      DEFAULT_SERVER_TIMEOUT_SECONDS
+    ),
+    skipCli: parseBoolean(cliValue('skip-cli', ['SMOKE_TEST_SKIP_CLI'])),
+    skipLibrary: parseBoolean(
+      cliValue('skip-library', ['SMOKE_TEST_SKIP_LIBRARY'])
+    ),
+    sleepSeconds: positiveValue(
+      'sleep-seconds',
+      ['SLEEP_SECONDS'],
+      DEFAULT_SLEEP_SECONDS
+    ),
+  };
+}
+
+export function getInstalledPackageJsonPath(workspace, packageName) {
+  return join(workspace, 'node_modules', packageName, 'package.json');
+}
+
+function readJsonFile(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+export function getBinEntries(packageJson, packageName) {
+  if (!packageJson.bin) {
+    return [];
+  }
+
+  if (typeof packageJson.bin === 'string') {
+    return [
+      {
+        name: packageName.split('/').pop(),
+        path: packageJson.bin,
+      },
+    ];
+  }
+
+  return Object.entries(packageJson.bin).map(([name, binPath]) => ({
+    name,
+    path: binPath,
+  }));
+}
+
+export function hasLibraryEntryPoint(packageJson) {
+  return Boolean(packageJson.exports || packageJson.main || packageJson.module);
+}
+
+export function resolveBinShim(
+  workspace,
+  binName,
+  platform = process.platform
+) {
+  const shimPath = join(workspace, 'node_modules', '.bin', binName);
+  return platform === 'win32' ? `${shimPath}.cmd` : shimPath;
+}
+
+export function formatOutputPreview(output, maxLines = DEFAULT_PREVIEW_LINES) {
+  return String(output).trimEnd().split(/\r?\n/).slice(0, maxLines).join('\n');
+}
+
+export function buildLibraryCheckSource(packageName) {
+  return [
+    `import * as packageModule from ${JSON.stringify(packageName)};`,
+    '',
+    'const exportNames = Object.keys(packageModule);',
+    'if (exportNames.length === 0) {',
+    "  throw new Error('Package import resolved but exposed no exports');",
+    '}',
+    'console.log(`library OK: imported exports ${exportNames.join(", ")}`);',
+    '',
+  ].join('\n');
+}
+
+function runCommand(command, args, options) {
+  return execFileSync(command, args, options);
+}
+
+function sleep(seconds) {
+  return new Promise((resolve) =>
+    globalThis.setTimeout(resolve, seconds * 1000)
+  );
+}
+
+export async function installFromNpm({
+  cwd,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  packageSpec,
+  runCommandFn = runCommand,
+  sleepFn = sleep,
+  sleepSeconds = DEFAULT_SLEEP_SECONDS,
+  stdout = console.log,
+}) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      stdout(
+        `Installing ${packageSpec} from npm (attempt ${attempt}/${maxAttempts})`
+      );
+      runCommandFn(
+        'npm',
+        [
+          'install',
+          packageSpec,
+          '--no-audit',
+          '--no-fund',
+          '--package-lock=false',
+        ],
+        { cwd, stdio: 'inherit' }
+      );
+      return;
+    } catch (error) {
+      if (attempt === maxAttempts) {
+        throw new Error(
+          `Failed to install ${packageSpec} after ${maxAttempts} attempts: ${error.message}`
+        );
+      }
+
+      stdout(
+        `Install failed; waiting ${sleepSeconds}s for npm registry propagation`
+      );
+      await sleepFn(sleepSeconds);
+    }
+  }
+}
+
+export function checkLibraryEntryPoint({
+  packageName,
+  runCommandFn = runCommand,
+  workspace,
+  writeFileFn = writeFileSync,
+}) {
+  const checkFile = join(workspace, 'check-library.mjs');
+  writeFileFn(checkFile, buildLibraryCheckSource(packageName));
+  runCommandFn(process.execPath, [checkFile], {
+    cwd: workspace,
+    stdio: 'inherit',
+  });
+}
+
+export function checkCliEntryPoints({
+  binEntries,
+  cliArgs = DEFAULT_CLI_ARGS,
+  runCommandFn = runCommand,
+  stdout = console.log,
+  workspace,
+}) {
+  for (const binEntry of binEntries) {
+    const binPath = resolveBinShim(workspace, binEntry.name);
+    stdout(`Checking CLI entry point: ${binEntry.name} ${cliArgs.join(' ')}`);
+    const output = runCommandFn(binPath, cliArgs, {
+      cwd: workspace,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    if (!String(output).trim()) {
+      throw new Error(`CLI ${binEntry.name} produced no stdout`);
+    }
+
+    stdout(formatOutputPreview(output));
+    stdout(`CLI OK: ${binEntry.name}`);
+  }
+}
+
+export function checkConfiguredLibraryEntryPoint({
+  installedPackageJson,
+  packageName,
+  runCommandFn = runCommand,
+  skipLibrary = false,
+  stdout = console.log,
+  workspace,
+}) {
+  if (skipLibrary || !hasLibraryEntryPoint(installedPackageJson)) {
+    stdout('No library smoke test configured; skipping');
+    return;
+  }
+
+  stdout('Checking library entry point');
+  checkLibraryEntryPoint({ packageName, runCommandFn, workspace });
+}
+
+export function checkConfiguredCliEntryPoints({
+  cliArgs = DEFAULT_CLI_ARGS,
+  installedPackageJson,
+  packageName,
+  runCommandFn = runCommand,
+  skipCli = false,
+  stdout = console.log,
+  workspace,
+}) {
+  const binEntries = getBinEntries(installedPackageJson, packageName);
+  if (skipCli || binEntries.length === 0) {
+    stdout('No CLI smoke test configured; skipping');
+    return;
+  }
+
+  checkCliEntryPoints({
+    binEntries,
+    cliArgs,
+    runCommandFn,
+    stdout,
+    workspace,
+  });
+}
+
+async function waitForHealth({
+  fetchFn = fetch,
+  sleepFn = sleep,
+  timeoutSeconds = DEFAULT_SERVER_TIMEOUT_SECONDS,
+  url,
+}) {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let lastError;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetchFn(url);
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`${url} returned status ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await sleepFn(1);
+  }
+
+  throw lastError || new Error(`Timed out waiting for ${url}`);
+}
+
+export async function checkServerEntryPoint({
+  runServerFn = spawn,
+  serverArgs = [],
+  serverBin,
+  serverHealthUrl,
+  serverTimeoutSeconds = DEFAULT_SERVER_TIMEOUT_SECONDS,
+  stdout = console.log,
+  workspace,
+}) {
+  if (!serverBin || !serverHealthUrl) {
+    stdout('No HTTP server smoke test configured; skipping');
+    return;
+  }
+
+  const binPath = resolveBinShim(workspace, serverBin);
+  stdout(
+    `Checking HTTP server entry point: ${serverBin} ${serverArgs.join(' ')}`
+  );
+  const child = runServerFn(binPath, serverArgs, {
+    cwd: workspace,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stderr = '';
+  child.stderr?.on('data', (chunk) => {
+    stderr += String(chunk);
+  });
+
+  try {
+    await waitForHealth({
+      timeoutSeconds: serverTimeoutSeconds,
+      url: serverHealthUrl,
+    });
+    stdout(`server OK: ${serverHealthUrl} responded`);
+  } catch (error) {
+    throw new Error(
+      `HTTP server smoke test failed: ${error.message}\nServer stderr:\n${stderr}`
+    );
+  } finally {
+    child.kill?.('SIGINT');
+  }
+}
+
+export async function smokeTestPackage({
+  cliArgs = DEFAULT_CLI_ARGS,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  packageName,
+  packageVersion,
+  runCommandFn = runCommand,
+  serverArgs = [],
+  serverBin = '',
+  serverHealthUrl = '',
+  serverTimeoutSeconds = DEFAULT_SERVER_TIMEOUT_SECONDS,
+  skipCli = false,
+  skipLibrary = false,
+  sleepFn = sleep,
+  sleepSeconds = DEFAULT_SLEEP_SECONDS,
+  stdout = console.log,
+  workspaceFactory = () => mkdtempSync(join(tmpdir(), 'npm-smoke-')),
+} = {}) {
+  const packageSpec = formatNpmPackageVersion(packageName, packageVersion);
+  const workspace = workspaceFactory();
+  stdout(`Smoke-testing installable package ${packageSpec}`);
+  stdout(`Workspace: ${workspace}`);
+
+  try {
+    writeFileSync(
+      join(workspace, 'package.json'),
+      JSON.stringify(
+        { name: 'npm-package-smoke-test', private: true, type: 'module' },
+        null,
+        2
+      )
+    );
+
+    await installFromNpm({
+      cwd: workspace,
+      maxAttempts,
+      packageSpec,
+      runCommandFn,
+      sleepFn,
+      sleepSeconds,
+      stdout,
+    });
+
+    const installedPackageJson = readJsonFile(
+      getInstalledPackageJsonPath(workspace, packageName)
+    );
+
+    checkConfiguredLibraryEntryPoint({
+      installedPackageJson,
+      packageName,
+      runCommandFn,
+      skipLibrary,
+      stdout,
+      workspace,
+    });
+
+    checkConfiguredCliEntryPoints({
+      cliArgs,
+      installedPackageJson,
+      packageName,
+      runCommandFn,
+      skipCli,
+      stdout,
+      workspace,
+    });
+
+    await checkServerEntryPoint({
+      serverArgs,
+      serverBin,
+      serverHealthUrl,
+      serverTimeoutSeconds,
+      stdout,
+      workspace,
+    });
+
+    stdout(`All configured entry points verified for ${packageSpec}`);
+  } finally {
+    rmSync(workspace, { force: true, recursive: true });
+  }
+}
+
+function isCliEntryPoint() {
+  return (
+    typeof process !== 'undefined' &&
+    process.argv?.[1] &&
+    fileURLToPath(import.meta.url) === resolve(process.argv[1])
+  );
+}
+
+export async function main({
+  argv = process.argv.slice(2),
+  env = process.env,
+  stderr = console.error,
+  stdout = console.log,
+} = {}) {
+  try {
+    const config = parseArgs(argv, env);
+    if (!config.packageVersion) {
+      stderr('Error: Missing required --package-version');
+      stderr(USAGE);
+      return 1;
+    }
+
+    const packageInfo = config.packageName
+      ? { name: config.packageName }
+      : readPackageInfo({ jsRoot: config.jsRoot || undefined });
+
+    await smokeTestPackage({
+      ...config,
+      packageName: packageInfo.name,
+      stdout: (message) => stdout(`[smoke-test] ${message}`),
+    });
+    return 0;
+  } catch (error) {
+    stderr(`[smoke-test] FAILED: ${error.message}`);
+    return 1;
+  }
+}
+
+if (isCliEntryPoint()) {
+  process.exitCode = await main();
+}

--- a/tests/smoke-test-package.test.js
+++ b/tests/smoke-test-package.test.js
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'test-anywhere';
+import { join } from 'node:path';
+
+import {
+  buildLibraryCheckSource,
+  checkCliEntryPoints,
+  formatOutputPreview,
+  getBinEntries,
+  hasLibraryEntryPoint,
+  installFromNpm,
+  parseArgs,
+  parseCommandArgs,
+  resolveBinShim,
+} from '../scripts/smoke-test-package.mjs';
+
+describe('smoke-test-package.mjs', () => {
+  it('parses package smoke test options', () => {
+    expect(
+      parseArgs(
+        [
+          '--package-version',
+          '1.2.3',
+          '--package-name=@scope/pkg',
+          '--max-attempts',
+          '2',
+          '--sleep-seconds=1',
+          '--cli-args',
+          'add 2 3',
+          '--server-bin',
+          'pkg',
+          '--server-args',
+          'serve --port 38217',
+          '--server-health-url',
+          'http://localhost:38217/health',
+        ],
+        {}
+      )
+    ).toEqual({
+      cliArgs: ['add', '2', '3'],
+      jsRoot: '',
+      maxAttempts: 2,
+      packageName: '@scope/pkg',
+      packageVersion: '1.2.3',
+      serverArgs: ['serve', '--port', '38217'],
+      serverBin: 'pkg',
+      serverHealthUrl: 'http://localhost:38217/health',
+      serverTimeoutSeconds: 15,
+      skipCli: false,
+      skipLibrary: false,
+      sleepSeconds: 1,
+    });
+  });
+
+  it('accepts JSON arrays for command arguments', () => {
+    expect(parseCommandArgs('["serve","--port","38217"]')).toEqual([
+      'serve',
+      '--port',
+      '38217',
+    ]);
+  });
+
+  it('requires values for non-boolean options', () => {
+    let errorMessage = '';
+
+    try {
+      parseArgs(['--package-version'], {});
+    } catch (error) {
+      errorMessage = error.message;
+    }
+
+    expect(errorMessage).toBe('Missing value for --package-version');
+  });
+
+  it('treats empty environment options as unset', () => {
+    expect(
+      parseArgs(['--package-version', '1.2.3'], { MAX_ATTEMPTS: '' })
+        .maxAttempts
+    ).toBe(5);
+  });
+
+  it('derives advertised npm bin entries', () => {
+    expect(
+      getBinEntries(
+        {
+          bin: {
+            pkg: './bin/pkg.js',
+            'pkg-admin': './bin/admin.js',
+          },
+        },
+        '@scope/pkg'
+      )
+    ).toEqual([
+      { name: 'pkg', path: './bin/pkg.js' },
+      { name: 'pkg-admin', path: './bin/admin.js' },
+    ]);
+
+    expect(getBinEntries({ bin: './cli.js' }, '@scope/pkg')).toEqual([
+      { name: 'pkg', path: './cli.js' },
+    ]);
+  });
+
+  it('detects whether the installed package has a library entry point', () => {
+    expect(hasLibraryEntryPoint({ exports: { '.': './index.js' } })).toBe(true);
+    expect(hasLibraryEntryPoint({ main: './index.js' })).toBe(true);
+    expect(hasLibraryEntryPoint({ bin: './cli.js' })).toBe(false);
+  });
+
+  it('builds a safe library import probe for scoped packages', () => {
+    const source = buildLibraryCheckSource('@scope/pkg');
+
+    expect(source).toContain('import * as packageModule from "@scope/pkg"');
+    expect(source).toContain('Object.keys(packageModule)');
+  });
+});
+
+describe('smoke-test-package entry point checks', () => {
+  it('resolves npm-installed bin shims for each platform', () => {
+    expect(resolveBinShim('/tmp/work', 'pkg', 'linux')).toBe(
+      join('/tmp/work', 'node_modules', '.bin', 'pkg')
+    );
+    expect(resolveBinShim('/tmp/work', 'pkg', 'win32')).toBe(
+      `${join('/tmp/work', 'node_modules', '.bin', 'pkg')}.cmd`
+    );
+  });
+
+  it('retries npm installs to absorb registry propagation lag', async () => {
+    let attempts = 0;
+    const sleeps = [];
+
+    await installFromNpm({
+      cwd: '/tmp/work',
+      maxAttempts: 3,
+      packageSpec: '@scope/pkg@1.2.3',
+      runCommandFn(command, args, options) {
+        attempts++;
+        expect(command).toBe('npm');
+        expect(args).toEqual([
+          'install',
+          '@scope/pkg@1.2.3',
+          '--no-audit',
+          '--no-fund',
+          '--package-lock=false',
+        ]);
+        expect(options.cwd).toBe('/tmp/work');
+
+        if (attempts === 1) {
+          throw new Error('registry lag');
+        }
+      },
+      sleepFn(seconds) {
+        sleeps.push(seconds);
+        return Promise.resolve();
+      },
+      sleepSeconds: 2,
+      stdout() {},
+    });
+
+    expect(attempts).toBe(2);
+    expect(sleeps).toEqual([2]);
+  });
+
+  it('captures CLI output before previewing it', () => {
+    const calls = [];
+    const logs = [];
+
+    checkCliEntryPoints({
+      binEntries: [{ name: 'pkg', path: './bin/pkg.js' }],
+      cliArgs: ['--list'],
+      runCommandFn(command, args, options) {
+        calls.push({ args, command, options });
+        return ['one', 'two', 'three', 'four', 'five', 'six'].join('\n');
+      },
+      stdout(message) {
+        logs.push(message);
+      },
+      workspace: '/tmp/work',
+    });
+
+    expect(calls.length).toBe(1);
+    expect(calls[0].command).toBe(resolveBinShim('/tmp/work', 'pkg'));
+    expect(calls[0].args).toEqual(['--list']);
+    expect(calls[0].options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+    expect(calls[0].options.encoding).toBe('utf8');
+    expect(logs).toContain(['one', 'two', 'three', 'four', 'five'].join('\n'));
+  });
+
+  it('previews captured output without using a live process pipe', () => {
+    expect(
+      formatOutputPreview(
+        ['one', 'two', 'three', 'four', 'five', 'six'].join('\n')
+      )
+    ).toBe(['one', 'two', 'three', 'four', 'five'].join('\n'));
+  });
+});

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -58,6 +58,16 @@ function evaluateWorkflowIf(expression, context) {
   )(context);
 }
 
+function expectOrdered(text, markers) {
+  let lastIndex = -1;
+
+  for (const marker of markers) {
+    const index = text.indexOf(marker);
+    expect(index).toBeGreaterThan(lastIndex);
+    lastIndex = index;
+  }
+}
+
 function createTestJobContext({
   eventName = 'pull_request',
   outputs = {},
@@ -216,6 +226,24 @@ describe('npm publish token bootstrap (issue #77)', () => {
 
       expect(job).toContain('node scripts/publish-to-npm.mjs');
       expect(job).toContain('NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}');
+    });
+  }
+});
+
+describe('install-from-package smoke test (issue #81)', () => {
+  for (const jobName of ['release', 'instant-release']) {
+    it(`smoke-tests the published npm package in the ${jobName} job`, () => {
+      const workflow = readWorkflow('.github/workflows/release.yml');
+      const job = getJobBlock(workflow, jobName);
+
+      expectOrdered(job, [
+        '- name: Publish to npm',
+        '- name: Smoke-test published npm package',
+        '- name: Create GitHub Release',
+      ]);
+      expect(job).toContain(
+        'node scripts/smoke-test-package.mjs --package-version "${{ steps.publish.outputs.published_version }}"'
+      );
     });
   }
 });


### PR DESCRIPTION
Fixes #81

## Summary
- Add `scripts/smoke-test-package.mjs` to install the just-published npm package into a clean temporary project from the public registry.
- Run the smoke test after `Publish to npm` and before `Create GitHub Release` in both `release` and `instant-release` jobs.
- Verify installed library entry points and package bin shims, with optional server health-check support for packages that expose an HTTP entry point.
- Add tests covering the new smoke-test script and workflow ordering, plus a patch changeset.

## Reproduction
Before the fix, the new workflow reliability test failed because neither release job contained a `Smoke-test published npm package` step between npm publish and GitHub Release creation.

## Validation
- `node --test --test-timeout=30000 tests/smoke-test-package.test.js`
- `node --test --test-timeout=30000 tests/workflow-reliability.test.js`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run check:duplication`
- `npm run check`
- `bun test --timeout 30000`
- `deno test --allow-read`
- `GITHUB_BASE_REF=main GITHUB_BASE_SHA=$(git merge-base origin/main HEAD) GITHUB_HEAD_SHA=$(git rev-parse HEAD) node scripts/validate-changeset.mjs`
- Live registry validation: `node scripts/smoke-test-package.mjs --package-name prettier --package-version 3.6.2 --max-attempts 1 --sleep-seconds 1`

I also tried the smoke test against `@link-foundation/example-package-name@0.11.8`; npm returned `E404` because that package version is not currently available from the registry, which is the exact class of failure this post-publish check is intended to surface.

## SIGPIPE Handling
CLI output is captured completely with `execFileSync(..., { stdio: ['ignore', 'pipe', 'pipe'] })` before previewing the first lines from the in-memory string. The workflow does not pipe live CLI output into `head`, so preview truncation cannot create false SIGPIPE failures.
