### PR TITLE
fix: auto-detect release naming for js monorepos

### DIFF
--- a/.changeset/issue-82-release-naming.md
+++ b/.changeset/issue-82-release-naming.md
@@ -1,0 +1,7 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Auto-detect single-language versus `js/` monorepo layouts when naming GitHub
+releases, namespace multi-language JavaScript tags as `js_v<version>`, and
+normalize prefixed tags before linking npm version badges.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-06-10T00:33:14.952Z for PR creation at branch issue-73-e14d5ef8be31 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/73
 # Updated: 2026-06-13T08:49:54.641Z
 # Updated: 2026-06-13T11:17:32.913Z
+# Updated: 2026-06-14T10:33:20.990Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-10T00:33:14.952Z for PR creation at branch issue-73-e14d5ef8be31 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/73
-# Updated: 2026-06-13T08:49:54.641Z
-# Updated: 2026-06-13T11:17:32.913Z
-# Updated: 2026-06-14T10:33:20.990Z

--- a/scripts/create-github-release.mjs
+++ b/scripts/create-github-release.mjs
@@ -2,11 +2,12 @@
 
 /**
  * Create GitHub Release from CHANGELOG.md
- * Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>]
+ * Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>] [--js-root <path>]
  *   release-version: Version number (e.g., 1.0.0)
  *   repository: GitHub repository (e.g., owner/repo)
- *   tag-prefix: Prefix for the git tag (default: "v", use "js-v" for multi-language repos)
+ *   tag-prefix: Prefix for the git tag (default: auto-detect from layout)
  *   language: Human-readable language name for the release title (default: "JavaScript")
+ *   js-root: JavaScript package root directory (auto-detected if not specified)
  */
 
 import { spawnSync } from 'node:child_process';
@@ -14,8 +15,23 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { getJsRoot } from './js-paths.mjs';
+import { readPackageInfo } from './package-info.mjs';
+import {
+  buildReleaseTag,
+  buildReleaseTitle,
+  normalizeReleaseVersion,
+} from './release-naming.mjs';
+
 const USAGE =
-  'Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>]';
+  'Usage: node scripts/create-github-release.mjs --release-version <version> --repository <repository> [--tag-prefix <prefix>] [--language <language>] [--js-root <path>]';
+const OPTION_CONFIG_KEYS = new Map([
+  ['--release-version', 'releaseVersion'],
+  ['--repository', 'repository'],
+  ['--tag-prefix', 'tagPrefix'],
+  ['--language', 'language'],
+  ['--js-root', 'jsRoot'],
+]);
 
 // Keep comfortably below GitHub's observed 125000-character release body limit.
 export const GITHUB_RELEASE_BODY_MAX_BYTES = 120_000;
@@ -23,39 +39,41 @@ const textEncoder = new globalThis.TextEncoder();
 
 export function parseArgs(argv, env = process.env) {
   const config = {
+    jsRoot: env.JS_ROOT ?? '',
     language: env.LANGUAGE ?? 'JavaScript',
     releaseVersion: env.VERSION ?? '',
     repository: env.REPOSITORY ?? '',
-    tagPrefix: env.TAG_PREFIX ?? 'v',
+    tagPrefix: env.TAG_PREFIX,
   };
 
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
+    const inlineValueIndex = arg.indexOf('=');
 
-    if (arg === '--release-version') {
-      config.releaseVersion = readOptionValue(argv, index, arg);
+    if (inlineValueIndex !== -1) {
+      assignOptionValue(
+        config,
+        arg.slice(0, inlineValueIndex),
+        arg.slice(inlineValueIndex + 1)
+      );
+      continue;
+    }
+
+    if (OPTION_CONFIG_KEYS.has(arg)) {
+      assignOptionValue(config, arg, readOptionValue(argv, index, arg));
       index++;
-    } else if (arg.startsWith('--release-version=')) {
-      config.releaseVersion = arg.slice('--release-version='.length);
-    } else if (arg === '--repository') {
-      config.repository = readOptionValue(argv, index, arg);
-      index++;
-    } else if (arg.startsWith('--repository=')) {
-      config.repository = arg.slice('--repository='.length);
-    } else if (arg === '--tag-prefix') {
-      config.tagPrefix = readOptionValue(argv, index, arg);
-      index++;
-    } else if (arg.startsWith('--tag-prefix=')) {
-      config.tagPrefix = arg.slice('--tag-prefix='.length);
-    } else if (arg === '--language') {
-      config.language = readOptionValue(argv, index, arg);
-      index++;
-    } else if (arg.startsWith('--language=')) {
-      config.language = arg.slice('--language='.length);
     }
   }
 
   return config;
+}
+
+function assignOptionValue(config, optionName, value) {
+  const configKey = OPTION_CONFIG_KEYS.get(optionName);
+
+  if (configKey) {
+    config[configKey] = value;
+  }
 }
 
 function readOptionValue(argv, index, optionName) {
@@ -86,26 +104,6 @@ export function extractReleaseNotes(changelog, version) {
   const releaseNotes = match[0].replace(`## ${version}`, '').trim();
 
   return releaseNotes || `Release ${version}`;
-}
-
-export function normalizeReleaseVersionForTitle(releaseVersion) {
-  const trimmedVersion = releaseVersion.trim();
-  const semverTagMatch = trimmedVersion.match(
-    /(?:^|[-_])v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/i
-  );
-
-  if (semverTagMatch) {
-    return semverTagMatch[1];
-  }
-
-  return trimmedVersion
-    .replace(/^[A-Za-z][A-Za-z0-9]*[-_]/, '')
-    .replace(/^v/i, '');
-}
-
-export function buildReleaseTitle(language, releaseVersion) {
-  const titleLanguage = language.trim() || 'JavaScript';
-  return `[${titleLanguage}] ${normalizeReleaseVersionForTitle(releaseVersion)}`;
 }
 
 function getUtf8ByteLength(value) {
@@ -171,16 +169,23 @@ export function limitReleaseNotesBytes({
 
 export function buildReleasePayload({
   changelog,
+  jsRoot = '.',
   language,
+  packageName,
   repository,
   tag,
   version,
 }) {
-  const releaseNotes = extractReleaseNotes(changelog, version);
+  const normalizedVersion = normalizeReleaseVersion(version);
+  const releaseNotes = extractReleaseNotes(changelog, normalizedVersion);
 
   return JSON.stringify({
     tag_name: tag,
-    name: buildReleaseTitle(language ?? 'JavaScript', tag),
+    name: buildReleaseTitle(tag, {
+      jsRoot,
+      language: language ?? 'JavaScript',
+      packageName,
+    }),
     body: limitReleaseNotesBytes({ releaseNotes, repository, tag }),
   });
 }
@@ -245,6 +250,7 @@ export function main({
   try {
     const {
       language,
+      jsRoot: configuredJsRoot,
       releaseVersion: version,
       repository,
       tagPrefix,
@@ -256,17 +262,24 @@ export function main({
       return 1;
     }
 
-    const tag = `${tagPrefix}${version}`;
+    const jsRoot = getJsRoot({ jsRoot: configuredJsRoot || undefined });
+    const tag = buildReleaseTag(version, { jsRoot, tagPrefix });
+    const normalizedVersion = normalizeReleaseVersion(version);
+    const { name: packageName } = readPackageInfo({ jsRoot });
 
     stdout(`Creating GitHub release for ${tag}...`);
 
-    const changelog = readFileSync(path.join(cwd, 'CHANGELOG.md'), 'utf8');
+    const changelogPath =
+      jsRoot === '.' ? 'CHANGELOG.md' : path.join(jsRoot, 'CHANGELOG.md');
+    const changelog = readFileSync(path.join(cwd, changelogPath), 'utf8');
     const payload = buildReleasePayload({
       changelog,
+      jsRoot,
       language,
+      packageName,
       repository,
       tag,
-      version,
+      version: normalizedVersion,
     });
     const result = createRelease({ payload, repository, spawn });
 

--- a/scripts/format-github-release.mjs
+++ b/scripts/format-github-release.mjs
@@ -2,17 +2,21 @@
 
 /**
  * Format GitHub release notes using the format-release-notes.mjs script
- * Usage: node scripts/format-github-release.mjs --release-version <version> --repository <repository> --commit-sha <commit_sha> [--tag-prefix <prefix>]
+ * Usage: node scripts/format-github-release.mjs --release-version <version> --repository <repository> --commit-sha <commit_sha> [--tag-prefix <prefix>] [--js-root <path>]
  *   release-version: Version number (e.g., 1.0.0)
  *   repository: GitHub repository (e.g., owner/repo)
  *   commit_sha: Commit SHA for PR detection
- *   tag-prefix: Prefix for the git tag (default: "v", use "js-v" for multi-language repos)
+ *   tag-prefix: Prefix for the git tag (default: auto-detect from layout)
+ *   js-root: JavaScript package root directory (auto-detected if not specified)
  *
  * Uses link-foundation libraries:
  * - use-m: Dynamic package loading without package.json dependencies
  * - command-stream: Modern shell command execution with streaming support
  * - lino-arguments: Unified configuration from CLI args, env vars, and .lenv files
  */
+
+import { getJsRoot, parseJsRootConfig } from './js-paths.mjs';
+import { buildReleaseTag, normalizeReleaseVersion } from './release-naming.mjs';
 
 // Load use-m dynamically
 const { use } = eval(
@@ -45,23 +49,41 @@ const config = makeConfig({
       })
       .option('tag-prefix', {
         type: 'string',
-        default: getenv('TAG_PREFIX', 'v'),
+        default: getenv('TAG_PREFIX', ''),
+        describe: 'Prefix for the git tag (auto-detected when omitted)',
+      })
+      .option('js-root', {
+        type: 'string',
+        default: getenv('JS_ROOT', ''),
         describe:
-          'Prefix for the git tag (e.g., "js-v" for multi-language repos)',
+          'JavaScript package root directory (auto-detected if not specified)',
       }),
 });
 
-const { releaseVersion: version, repository, commitSha, tagPrefix } = config;
+const {
+  releaseVersion: version,
+  repository,
+  commitSha,
+  tagPrefix: configuredTagPrefix,
+  jsRoot: configuredJsRoot,
+} = config;
 
 if (!version || !repository || !commitSha) {
   console.error('Error: Missing required arguments');
   console.error(
-    'Usage: node scripts/format-github-release.mjs --release-version <version> --repository <repository> --commit-sha <commit_sha> [--tag-prefix <prefix>]'
+    'Usage: node scripts/format-github-release.mjs --release-version <version> --repository <repository> --commit-sha <commit_sha> [--tag-prefix <prefix>] [--js-root <path>]'
   );
   process.exit(1);
 }
 
-const tag = `${tagPrefix}${version}`;
+const jsRoot = getJsRoot({
+  jsRoot: configuredJsRoot || parseJsRootConfig() || undefined,
+});
+const tag = buildReleaseTag(version, {
+  jsRoot,
+  tagPrefix: configuredTagPrefix || undefined,
+});
+const normalizedVersion = normalizeReleaseVersion(version);
 
 try {
   // Get the release ID for this version
@@ -81,7 +103,7 @@ try {
     console.log(`Formatting release notes for ${tag}...`);
     // Pass the trigger commit SHA for PR detection
     // This allows proper PR lookup even if the changelog doesn't have a commit hash
-    await $`node scripts/format-release-notes.mjs --release-id "${releaseId}" --release-version "${tag}" --repository "${repository}" --commit-sha "${commitSha}"`;
+    await $`node scripts/format-release-notes.mjs --release-id "${releaseId}" --release-version "${normalizedVersion}" --repository "${repository}" --commit-sha "${commitSha}"`;
     console.log(`\u2705 Formatted release notes for ${tag}`);
   }
 } catch (error) {

--- a/scripts/format-release-notes-helpers.mjs
+++ b/scripts/format-release-notes-helpers.mjs
@@ -1,16 +1,7 @@
+import { normalizeReleaseVersion } from './release-naming.mjs';
+
 export function normalizeReleaseVersionForBadge(releaseVersion) {
-  const trimmedVersion = releaseVersion.trim();
-  const semverTagMatch = trimmedVersion.match(
-    /(?:^|-)v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/i
-  );
-
-  if (semverTagMatch) {
-    return semverTagMatch[1];
-  }
-
-  return trimmedVersion
-    .replace(/^[A-Za-z][A-Za-z0-9]*-/, '')
-    .replace(/^v/i, '');
+  return normalizeReleaseVersion(releaseVersion);
 }
 
 export function encodeShieldsStaticBadgeSegment(value) {

--- a/scripts/release-naming.mjs
+++ b/scripts/release-naming.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+/**
+ * Release naming conventions for JavaScript package releases.
+ *
+ * A root package.json means the JavaScript package is the whole repository.
+ * A js/package.json means releases share the repository with other languages
+ * and need a language namespace in GitHub Releases.
+ */
+
+import { getJsRoot } from './js-paths.mjs';
+
+const DEFAULT_LANGUAGE = 'JavaScript';
+const MULTI_LANGUAGE_TAG_PREFIX = 'js_v';
+const SINGLE_LANGUAGE_TAG_PREFIX = 'v';
+
+export function isMultiLanguage(options = {}) {
+  return getJsRoot(options) !== '.';
+}
+
+export function getDefaultTagPrefix(options = {}) {
+  return isMultiLanguage(options)
+    ? MULTI_LANGUAGE_TAG_PREFIX
+    : SINGLE_LANGUAGE_TAG_PREFIX;
+}
+
+export function getReleaseTagPrefix(options = {}) {
+  if (options.tagPrefix !== undefined && options.tagPrefix !== null) {
+    return String(options.tagPrefix);
+  }
+
+  return getDefaultTagPrefix(options);
+}
+
+export function normalizeReleaseVersion(releaseVersion) {
+  const trimmedVersion = String(releaseVersion ?? '').trim();
+
+  if (!trimmedVersion) {
+    return '';
+  }
+
+  const semverTagMatch = trimmedVersion.match(
+    /(?:^|[-_])v?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/i
+  );
+
+  if (semverTagMatch) {
+    return semverTagMatch[1];
+  }
+
+  return trimmedVersion
+    .replace(/^[A-Za-z][A-Za-z0-9]*[-_]v?/i, '')
+    .replace(/^v/i, '');
+}
+
+export function buildReleaseTag(releaseVersion, options = {}) {
+  return `${getReleaseTagPrefix(options)}${normalizeReleaseVersion(
+    releaseVersion
+  )}`;
+}
+
+export function buildReleaseTitle(releaseVersion, options = {}) {
+  const titleVersion = normalizeReleaseVersion(releaseVersion);
+  const language = (options.language ?? DEFAULT_LANGUAGE).trim();
+  const titleLanguage = language || DEFAULT_LANGUAGE;
+
+  if (isMultiLanguage(options)) {
+    return `[${titleLanguage}] ${titleVersion}`;
+  }
+
+  const packageName = (options.packageName ?? '').trim();
+  const singleLanguageName = packageName || titleLanguage;
+
+  return `${singleLanguageName} ${titleVersion}`;
+}

--- a/tests/create-github-release.test.js
+++ b/tests/create-github-release.test.js
@@ -66,13 +66,22 @@ function prependPath(env, binPath) {
   };
 }
 
-function createFixture() {
+function createFixture({ jsRoot = '.' } = {}) {
   const root = mkdtempSync(path.join(tmpdir(), 'create-release-'));
   const binPath = path.join(root, 'bin');
+  const packageRoot = jsRoot === '.' ? root : path.join(root, jsRoot);
 
   mkdirSync(binPath, { recursive: true });
+  mkdirSync(packageRoot, { recursive: true });
   writeFileSync(
-    path.join(root, 'CHANGELOG.md'),
+    path.join(packageRoot, 'package.json'),
+    JSON.stringify({
+      name: jsRoot === '.' ? 'fixture-package' : '@scope/js-package',
+      version: '1.2.3',
+    })
+  );
+  writeFileSync(
+    path.join(packageRoot, 'CHANGELOG.md'),
     `# Changelog
 
 ## 1.2.3
@@ -194,32 +203,36 @@ function getUtf8ByteLength(value) {
 describe('create-github-release release title formatting', () => {
   it('parses language from CLI arguments and environment defaults', () => {
     expect(parseArgs([], {})).toEqual({
+      jsRoot: '',
       language: 'JavaScript',
       releaseVersion: '',
       repository: '',
-      tagPrefix: 'v',
+      tagPrefix: undefined,
     });
     expect(parseArgs([], { LANGUAGE: 'TypeScript' })).toEqual({
+      jsRoot: '',
       language: 'TypeScript',
       releaseVersion: '',
       repository: '',
-      tagPrefix: 'v',
+      tagPrefix: undefined,
     });
     expect(parseArgs(['--language', 'JavaScript'], {})).toEqual({
+      jsRoot: '',
       language: 'JavaScript',
       releaseVersion: '',
       repository: '',
-      tagPrefix: 'v',
+      tagPrefix: undefined,
     });
     expect(parseArgs(['--language=Rust'], {})).toEqual({
+      jsRoot: '',
       language: 'Rust',
       releaseVersion: '',
       repository: '',
-      tagPrefix: 'v',
+      tagPrefix: undefined,
     });
   });
 
-  it('builds a human-readable release name from a language-prefixed tag', () => {
+  it('builds a human-readable release name from a multi-language tag', () => {
     const changelog = `# Changelog
 
 ## 1.2.3
@@ -231,13 +244,15 @@ describe('create-github-release release title formatting', () => {
       JSON.parse(
         buildReleasePayload({
           changelog,
+          jsRoot: 'js',
           language: 'JavaScript',
-          tag: 'js-v1.2.3',
+          packageName: '@scope/js-package',
+          tag: 'js_v1.2.3',
           version: '1.2.3',
         })
       )
     ).toEqual({
-      tag_name: 'js-v1.2.3',
+      tag_name: 'js_v1.2.3',
       name: '[JavaScript] 1.2.3',
       body: '- Fix release creation',
     });
@@ -375,7 +390,7 @@ describe('create-github-release.mjs', () => {
         ]);
         expect(JSON.parse(readFileSync(payloadFile, 'utf8'))).toEqual({
           tag_name: 'v1.2.3',
-          name: '[JavaScript] 1.2.3',
+          name: 'fixture-package 1.2.3',
           body: '### Patch Changes\n\n- Fix release creation',
         });
       } finally {
@@ -383,23 +398,18 @@ describe('create-github-release.mjs', () => {
       }
     });
 
-    it('passes a human-readable release name for language-prefixed tags', () => {
-      const root = createFixture();
+    it('auto-detects multi-language release tags and titles', () => {
+      const root = createFixture({ jsRoot: 'js' });
 
       try {
-        const { payloadFile, result } = runCreateRelease(root, 'success', [
-          '--tag-prefix',
-          'js-v',
-          '--language',
-          'JavaScript',
-        ]);
+        const { payloadFile, result } = runCreateRelease(root, 'success');
 
         expect(result.status).toBe(0);
         expect(result.stdout).toContain(
-          'Creating GitHub release for js-v1.2.3'
+          'Creating GitHub release for js_v1.2.3'
         );
         expect(JSON.parse(readFileSync(payloadFile, 'utf8'))).toEqual({
-          tag_name: 'js-v1.2.3',
+          tag_name: 'js_v1.2.3',
           name: '[JavaScript] 1.2.3',
           body: '### Patch Changes\n\n- Fix release creation',
         });

--- a/tests/release-badge.test.js
+++ b/tests/release-badge.test.js
@@ -20,8 +20,16 @@ describe('release badge version normalization', () => {
     expect(normalizeReleaseVersionForBadge('js-v1.7.12')).toBe('1.7.12');
   });
 
+  it('strips a js_v prefix from auto-detected multi-language release tags', () => {
+    expect(normalizeReleaseVersionForBadge('js_v1.7.12')).toBe('1.7.12');
+  });
+
   it('strips a rust-v prefix from multi-language release tags', () => {
     expect(normalizeReleaseVersionForBadge('rust-v0.3.4')).toBe('0.3.4');
+  });
+
+  it('strips a rust_v prefix from multi-language release tags', () => {
+    expect(normalizeReleaseVersionForBadge('rust_v0.3.4')).toBe('0.3.4');
   });
 
   it('escapes hyphens in prerelease versions for shields.io static badge paths', () => {
@@ -31,15 +39,15 @@ describe('release badge version normalization', () => {
   });
 
   it('builds a valid shields.io badge URL for prefixed tags', () => {
-    const badge = buildNpmVersionBadge('my-package', 'js-v1.7.12');
+    const badge = buildNpmVersionBadge('my-package', 'js_v1.7.12');
 
     expect(badge.includes('/badge/npm-1.7.12-blue.svg')).toBe(true);
-    expect(badge.includes('/badge/npm-js-v1.7.12-blue.svg')).toBe(false);
+    expect(badge.includes('/badge/npm-js_v1.7.12-blue.svg')).toBe(false);
     expect(badge.includes('/my-package/v/1.7.12')).toBe(true);
   });
 
   it('builds a valid shields.io badge URL for prefixed prerelease tags', () => {
-    const badge = buildNpmVersionBadge('my-package', 'js-v1.0.0-alpha.1');
+    const badge = buildNpmVersionBadge('my-package', 'js_v1.0.0-alpha.1');
 
     expect(badge.includes('/badge/npm-1.0.0--alpha.1-blue.svg')).toBe(true);
     expect(badge.includes('/my-package/v/1.0.0-alpha.1')).toBe(true);

--- a/tests/release-naming.test.js
+++ b/tests/release-naming.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'test-anywhere';
+
+import {
+  buildReleaseTag,
+  buildReleaseTitle,
+  getDefaultTagPrefix,
+  getReleaseTagPrefix,
+  isMultiLanguage,
+  normalizeReleaseVersion,
+} from '../scripts/release-naming.mjs';
+
+const MULTI = { jsRoot: 'js' };
+const SINGLE = { jsRoot: '.' };
+
+describe('release naming layout detection', () => {
+  it('treats js/package.json layouts as multi-language', () => {
+    expect(isMultiLanguage(MULTI)).toBe(true);
+  });
+
+  it('treats root package.json layouts as single-language', () => {
+    expect(isMultiLanguage(SINGLE)).toBe(false);
+  });
+});
+
+describe('release naming tag prefixes', () => {
+  it('uses js_v for auto-detected multi-language releases', () => {
+    expect(getDefaultTagPrefix(MULTI)).toBe('js_v');
+  });
+
+  it('uses v for auto-detected single-language releases', () => {
+    expect(getDefaultTagPrefix(SINGLE)).toBe('v');
+  });
+
+  it('keeps an explicit tag prefix override', () => {
+    expect(getReleaseTagPrefix({ ...MULTI, tagPrefix: 'js-v' })).toBe('js-v');
+  });
+});
+
+describe('release naming tag construction', () => {
+  it('builds js_v tags in multi-language mode', () => {
+    expect(buildReleaseTag('1.2.3', MULTI)).toBe('js_v1.2.3');
+  });
+
+  it('builds plain v tags in single-language mode', () => {
+    expect(buildReleaseTag('1.2.3', SINGLE)).toBe('v1.2.3');
+  });
+
+  it('does not double-prefix an already namespaced multi-language version', () => {
+    expect(buildReleaseTag('js_v1.2.3', MULTI)).toBe('js_v1.2.3');
+    expect(buildReleaseTag('js-v1.2.3', MULTI)).toBe('js_v1.2.3');
+  });
+
+  it('does not double-prefix an already tagged single-language version', () => {
+    expect(buildReleaseTag('v1.2.3', SINGLE)).toBe('v1.2.3');
+  });
+
+  it('supports explicit legacy dash prefixes', () => {
+    expect(buildReleaseTag('1.2.3', { ...MULTI, tagPrefix: 'js-v' })).toBe(
+      'js-v1.2.3'
+    );
+  });
+
+  it('works with prerelease and build metadata versions', () => {
+    expect(buildReleaseTag('1.2.3-beta.1+build.5', MULTI)).toBe(
+      'js_v1.2.3-beta.1+build.5'
+    );
+  });
+});
+
+describe('release naming title construction', () => {
+  it('prefixes the language in multi-language mode', () => {
+    expect(buildReleaseTitle('1.2.3', MULTI)).toBe('[JavaScript] 1.2.3');
+  });
+
+  it('uses package name and version in single-language mode', () => {
+    expect(
+      buildReleaseTitle('1.2.3', {
+        ...SINGLE,
+        packageName: '@scope/package-name',
+      })
+    ).toBe('@scope/package-name 1.2.3');
+  });
+
+  it('normalizes prefixed versions before building multi-language titles', () => {
+    expect(buildReleaseTitle('js_v1.2.3', MULTI)).toBe('[JavaScript] 1.2.3');
+  });
+
+  it('normalizes prefixed versions before building single-language titles', () => {
+    expect(
+      buildReleaseTitle('v1.2.3', {
+        ...SINGLE,
+        packageName: 'package-name',
+      })
+    ).toBe('package-name 1.2.3');
+  });
+
+  it('falls back to JavaScript when a single-language package name is unavailable', () => {
+    expect(buildReleaseTitle('1.2.3', SINGLE)).toBe('JavaScript 1.2.3');
+  });
+});
+
+describe('release naming version normalization', () => {
+  const cases = [
+    ['1.2.3', '1.2.3'],
+    ['v1.2.3', '1.2.3'],
+    ['V1.2.3', '1.2.3'],
+    ['js_v1.2.3', '1.2.3'],
+    ['js-v1.2.3', '1.2.3'],
+    ['rust_v0.3.4', '0.3.4'],
+    ['rust-v0.3.4', '0.3.4'],
+    ['csharp_v2.0.0', '2.0.0'],
+    ['js_v1.2.3-beta.1', '1.2.3-beta.1'],
+    ['js_v1.2.3+build.5', '1.2.3+build.5'],
+    ['', ''],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`normalizes ${JSON.stringify(input)} to ${JSON.stringify(
+      expected
+    )}`, () => {
+      expect(normalizeReleaseVersion(input)).toBe(expected);
+    });
+  }
+});

--- a/tests/tag-prefix.test.js
+++ b/tests/tag-prefix.test.js
@@ -5,29 +5,38 @@
 
 import { describe, it, expect } from 'test-anywhere';
 
-// Simulate the tag construction logic from both scripts
-function buildTag(version, tagPrefix = 'v') {
-  return `${tagPrefix}${version}`;
-}
+import { buildReleaseTag } from '../scripts/release-naming.mjs';
 
 describe('tag prefix logic', () => {
   it('defaults to "v" prefix (backward compatible)', () => {
-    expect(buildTag('1.0.0')).toBe('v1.0.0');
+    expect(buildReleaseTag('1.0.0', { jsRoot: '.' })).toBe('v1.0.0');
   });
 
-  it('supports "js-v" prefix for multi-language repos', () => {
-    expect(buildTag('1.0.0', 'js-v')).toBe('js-v1.0.0');
+  it('auto-detects "js_v" prefix for multi-language repos', () => {
+    expect(buildReleaseTag('1.0.0', { jsRoot: 'js' })).toBe('js_v1.0.0');
+  });
+
+  it('keeps explicit "js-v" prefix overrides for compatibility', () => {
+    expect(buildReleaseTag('1.0.0', { jsRoot: 'js', tagPrefix: 'js-v' })).toBe(
+      'js-v1.0.0'
+    );
   });
 
   it('supports "rust-v" prefix', () => {
-    expect(buildTag('1.7.8', 'rust-v')).toBe('rust-v1.7.8');
+    expect(
+      buildReleaseTag('1.7.8', { jsRoot: 'js', tagPrefix: 'rust-v' })
+    ).toBe('rust-v1.7.8');
   });
 
   it('supports empty prefix', () => {
-    expect(buildTag('2.3.4', '')).toBe('2.3.4');
+    expect(buildReleaseTag('2.3.4', { jsRoot: '.', tagPrefix: '' })).toBe(
+      '2.3.4'
+    );
   });
 
   it('works with pre-release versions', () => {
-    expect(buildTag('1.0.0-alpha.1', 'js-v')).toBe('js-v1.0.0-alpha.1');
+    expect(buildReleaseTag('1.0.0-alpha.1', { jsRoot: 'js' })).toBe(
+      'js_v1.0.0-alpha.1'
+    );
   });
 });


### PR DESCRIPTION
Fixes #82.

## Summary

- Add a shared `scripts/release-naming.mjs` helper for JavaScript release layout detection, idempotent version normalization, tag construction, and title construction.
- Auto-detect root `package.json` vs `js/package.json`: single-language releases keep `v<version>` tags and `<package-name> <version>` titles; multi-language releases use `js_v<version>` tags and `[JavaScript] <version>` titles.
- Keep explicit `--tag-prefix` / `TAG_PREFIX` overrides working for existing callers while making the default zero-config path layout-aware.
- Normalize `js_v...`, `js-v...`, `rust_v...`, and plain `v...` tags before building npm badge version links.
- Add the required patch changeset and remove the initial PR placeholder `.gitkeep`.

## Reproduction / Coverage

The previous release helper behavior was covered only by manual tag-prefix concatenation tests, so a `js/` package layout still defaulted to `v<version>` unless configured by hand. New tests cover auto-detected `js_v<version>` tags, single-language `v<version>` tags, title formatting, explicit legacy prefix overrides, and idempotent already-prefixed inputs.

## Verification

- `node --test tests/release-naming.test.js tests/create-github-release.test.js tests/release-badge.test.js tests/tag-prefix.test.js`
- `bash scripts/check-mjs-syntax.sh`
- `npm test`
- `npm run check`
- `bash scripts/check-file-line-limits.sh`
- `node scripts/validate-changeset.mjs`
