### PR TITLE
fix: exclude Vite source HTML from link checks

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -45,6 +45,8 @@ jobs:
           # Exclude case-studies directory - these are research documents from
           # external repos with references to files and issues that don't exist
           # in this repository (similar exclusion pattern as eslint.config.js)
+          # Exclude the Vite source HTML because its root-relative app asset
+          # URLs are only valid when served by Vite.
           args: >-
             --verbose
             --no-progress
@@ -53,6 +55,7 @@ jobs:
             --max-retries 3
             --timeout 30
             --exclude-path docs/case-studies
+            --exclude-path examples/universal-app/index.html
             './**/*.md'
             './**/*.html'
           # Don't fail the workflow immediately - we want to check web archive first

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-26T18:33:34.505Z for PR creation at branch issue-95-1521bdf3c8af for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/95

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-26T18:33:34.505Z for PR creation at branch issue-95-1521bdf3c8af for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/95

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -120,6 +120,22 @@ describe('workflow reliability policy', () => {
     }
   });
 
+  it('excludes Vite source HTML from raw lychee file scans', () => {
+    const linksWorkflow = readWorkflow('.github/workflows/links.yml');
+    const viteSourceHtmlPath = 'examples/universal-app/index.html';
+    const viteSourceHtml = readWorkflow(viteSourceHtmlPath);
+
+    expect(viteSourceHtml).toContain('href="/favicon.svg"');
+    expect(viteSourceHtml).toContain('src="/src/main.js"');
+    expect(linksWorkflow).toContain(`--exclude-path ${viteSourceHtmlPath}`);
+    expectOrdered(linksWorkflow, [
+      '--exclude-path docs/case-studies',
+      `--exclude-path ${viteSourceHtmlPath}`,
+      "'./**/*.md'",
+      "'./**/*.html'",
+    ]);
+  });
+
   it('uploads preview regeneration artifacts when screenshot rendering fails', () => {
     const exampleAppWorkflow = readWorkflow(
       '.github/workflows/example-app.yml'
@@ -141,7 +157,7 @@ describe('workflow reliability policy', () => {
     expect(previewRegenJob).toContain('if-no-files-found: ignore');
   });
 
-  it('uses the official Playwright image for preview regeneration instead of downloading Chromium', () => {
+  it('uses the official Playwright image for preview regeneration with browser downloads disabled', () => {
     const exampleAppWorkflow = readWorkflow(
       '.github/workflows/example-app.yml'
     );
@@ -214,7 +230,7 @@ describe('release workflow change gates', () => {
   });
 });
 
-describe('npm publish token bootstrap (issue #77)', () => {
+describe('npm publish token bootstrap', () => {
   // The first publish of a brand-new package cannot use OIDC trusted publishing
   // (npm returns E404 because a trusted publisher can only be configured for an
   // existing package). Every Publish-to-npm step must therefore expose an
@@ -230,7 +246,7 @@ describe('npm publish token bootstrap (issue #77)', () => {
   }
 });
 
-describe('install-from-package smoke test (issue #81)', () => {
+describe('install-from-package smoke test', () => {
   for (const jobName of ['release', 'instant-release']) {
     it(`smoke-tests the published npm package in the ${jobName} job`, () => {
       const workflow = readWorkflow('.github/workflows/release.yml');


### PR DESCRIPTION
## What

Fixes #95 by excluding `examples/universal-app/index.html` from the raw lychee `*.html` scan. That file is Vite source HTML with root-relative app assets (`/favicon.svg`, `/src/main.js`) that are valid when served by Vite but fail when lychee reads the file directly from a checkout.

## Reproduction

Before the exclusion, a narrow lychee container run against the source HTML failed with exit code 2 and:

```text
Cannot resolve root-relative link '/favicon.svg'
```

With `--exclude-path examples/universal-app/index.html`, the same source-file check exits 0 and scans 0 links for that excluded input.

## Testing

- Added a regression test in `tests/workflow-reliability.test.js` that asserts the Vite source HTML remains excluded before the raw Markdown/HTML globs.
- `npm test`
- `npm run check`
- `bun test --timeout 30000`
- `deno test --allow-read`

No changeset is included because this is a CI workflow/test-only change and does not alter the published package API.
