### PR TITLE
fix: harden generated preview pushes

### DIFF
--- a/.changeset/preview-push-retry.md
+++ b/.changeset/preview-push-retry.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Harden generated preview-image pushes against main branch non-fast-forward races.

--- a/.github/workflows/example-app.yml
+++ b/.github/workflows/example-app.yml
@@ -216,6 +216,9 @@ jobs:
       # Keep this tag in sync with the playwright package version below.
       image: mcr.microsoft.com/playwright:v1.59.1-noble
     timeout-minutes: 20
+    concurrency:
+      group: main-writer-${{ github.repository }}-main
+      cancel-in-progress: false
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
@@ -272,7 +275,7 @@ jobs:
           # [skip ci] prevents an infinite re-run loop; the next push to main
           # will pick up these fresh images for the regular pages-build.
           git commit -m "chore(preview): regenerate example-app preview images [skip ci]"
-          git push origin HEAD:main
+          bash scripts/push-main-with-rebase-retry.sh
 
       - name: Upload screenshot failure artifacts
         if: failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -373,6 +373,9 @@ jobs:
     # Typical run is well under 10min. 30min gives npm and GitHub
     # release APIs room for retries without allowing a 6h hang.
     timeout-minutes: 30
+    concurrency:
+      group: main-writer-${{ github.repository }}-main
+      cancel-in-progress: false
     # Use !cancelled() instead of always() so cancellation propagates correctly (hive-mind issue #1278)
     # This is needed because lint/test jobs have a transitive dependency on changeset-check
     if: |
@@ -472,6 +475,9 @@ jobs:
     runs-on: ubuntu-latest
     # Same publish envelope as the automated release path.
     timeout-minutes: 30
+    concurrency:
+      group: main-writer-${{ github.repository }}-main
+      cancel-in-progress: false
     # Permissions required for npm OIDC trusted publishing
     permissions:
       contents: write

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-03T15:41:50.499Z for PR creation at branch issue-98-6ad7eaf94297 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/98

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-03T15:41:50.499Z for PR creation at branch issue-98-6ad7eaf94297 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/98

--- a/scripts/push-main-with-rebase-retry.sh
+++ b/scripts/push-main-with-rebase-retry.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+remote="${1:-origin}"
+branch="${2:-main}"
+
+if git push "$remote" "HEAD:$branch"; then
+  echo "Push succeeded."
+  exit 0
+fi
+
+echo "::warning::Initial push failed; rebasing on ${remote}/${branch} before retry."
+git pull --rebase "$remote" "$branch"
+git push "$remote" "HEAD:$branch"
+echo "Push succeeded after rebase retry."

--- a/scripts/version-and-commit.mjs
+++ b/scripts/version-and-commit.mjs
@@ -14,11 +14,6 @@
  * - use-m: Dynamic package loading without package.json dependencies
  * - command-stream: Modern shell command execution with streaming support
  * - lino-arguments: Unified configuration from CLI args, env vars, and .lenv files
- *
- * Addresses issues documented in:
- * - Issue #21: Supporting both single and multi-language repository structures
- * - Reference: link-assistant/agent PR #112 (--legacy-peer-deps fix)
- * - Reference: link-assistant/agent PR #114 (configurable package root)
  */
 
 import { readFileSync, appendFileSync, readdirSync } from 'fs';
@@ -264,8 +259,9 @@ async function main() {
       const escapedMessage = commitMessage.replace(/"/g, '\\"');
       await $`git commit -m "${escapedMessage}"`;
 
-      // Push directly to main
-      await $`git push origin main`;
+      // Push directly to main, rebasing and retrying if another main writer won
+      // the race between this commit and the push.
+      await $`bash scripts/push-main-with-rebase-retry.sh`;
 
       console.log('\u2705 Version bump committed and pushed to main');
       setOutput('version_committed', 'true');

--- a/tests/push-main-with-rebase-retry.test.js
+++ b/tests/push-main-with-rebase-retry.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'test-anywhere';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, URL } from 'node:url';
+
+const scriptPath = fileURLToPath(
+  new URL('../scripts/push-main-with-rebase-retry.sh', import.meta.url)
+);
+const isDenoRuntime = typeof Deno !== 'undefined';
+const canRunGitFixtures =
+  !isDenoRuntime &&
+  typeof process !== 'undefined' &&
+  process.platform !== 'win32';
+
+function runCommand(command, args, cwd) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} failed\nstdout:\n${
+        result.stdout
+      }\nstderr:\n${result.stderr}`
+    );
+  }
+
+  return result;
+}
+
+function runGit(root, args) {
+  return runCommand('git', args, root);
+}
+
+function configureGit(root) {
+  runGit(root, ['config', 'user.email', 'ci@example.com']);
+  runGit(root, ['config', 'user.name', 'CI Test']);
+}
+
+function commitAll(root, message) {
+  runGit(root, ['add', '.']);
+  runGit(root, ['commit', '-m', message]);
+}
+
+function createFile(root, filePath, contents) {
+  const absolutePath = path.join(root, filePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, contents);
+}
+
+function runPushHelper(root) {
+  return spawnSync('bash', [scriptPath], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+}
+
+describe('push-main-with-rebase-retry.sh', () => {
+  if (canRunGitFixtures) {
+    it('rebases and retries when a generated-artifact push races another main writer', () => {
+      const root = mkdtempSync(path.join(tmpdir(), 'push-main-retry-'));
+      const remote = path.join(root, 'remote.git');
+      const previewWriter = path.join(root, 'preview-writer');
+      const releaseWriter = path.join(root, 'release-writer');
+      const verifier = path.join(root, 'verifier');
+
+      try {
+        runGit(root, ['init', '--bare', '--initial-branch=main', remote]);
+        runGit(root, ['clone', remote, previewWriter]);
+        configureGit(previewWriter);
+        createFile(previewWriter, 'README.md', '# Fixture\n');
+        commitAll(previewWriter, 'Initial commit');
+        runGit(previewWriter, ['push', 'origin', 'HEAD:main']);
+
+        runGit(root, ['clone', remote, releaseWriter]);
+        configureGit(releaseWriter);
+
+        createFile(
+          previewWriter,
+          'docs/screenshots/example-app/example-app.png',
+          'new preview image\n'
+        );
+        commitAll(previewWriter, 'Regenerate preview images');
+
+        createFile(releaseWriter, 'VERSION.txt', '1.0.1\n');
+        commitAll(releaseWriter, 'Version bump');
+        runGit(releaseWriter, ['push', 'origin', 'HEAD:main']);
+
+        const result = runPushHelper(previewWriter);
+        const output = `${result.stdout}\n${result.stderr}`;
+
+        expect(result.status).toBe(0);
+        expect(output).toContain('rebasing on origin/main before retry');
+        expect(output).toContain('Push succeeded after rebase retry.');
+
+        runGit(root, ['clone', remote, verifier]);
+        const history = runGit(verifier, ['log', '--format=%s']).stdout;
+
+        expect(history).toContain('Regenerate preview images');
+        expect(history).toContain('Version bump');
+        expect(
+          readFileSync(
+            path.join(verifier, 'docs/screenshots/example-app/example-app.png'),
+            'utf8'
+          )
+        ).toBe('new preview image\n');
+        expect(readFileSync(path.join(verifier, 'VERSION.txt'), 'utf8')).toBe(
+          '1.0.1\n'
+        );
+      } finally {
+        rmSync(root, { force: true, recursive: true });
+      }
+    });
+  }
+});

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -68,6 +68,12 @@ function expectOrdered(text, markers) {
   }
 }
 
+function expectMainWriterConcurrency(jobBlock) {
+  expect(jobBlock).toContain(
+    '    concurrency:\n      group: main-writer-${{ github.repository }}-main\n      cancel-in-progress: false'
+  );
+}
+
 function createTestJobContext({
   eventName = 'pull_request',
   outputs = {},
@@ -173,6 +179,32 @@ describe('workflow reliability policy', () => {
     expect(previewRegenJob).toContain("PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'");
     expect(previewRegenJob).not.toContain('npx playwright install');
     expect(previewRegenJob).not.toContain('~/.cache/ms-playwright');
+  });
+
+  it('serializes main writers and retries generated pushes after rebasing', () => {
+    const exampleAppWorkflow = readWorkflow(
+      '.github/workflows/example-app.yml'
+    );
+    const releaseWorkflow = readWorkflow('.github/workflows/release.yml');
+    const pushHelper = readWorkflow('scripts/push-main-with-rebase-retry.sh');
+    const versionAndCommit = readWorkflow('scripts/version-and-commit.mjs');
+    const previewRegenJob = getJobBlock(exampleAppWorkflow, 'preview-regen');
+    const releaseJob = getJobBlock(releaseWorkflow, 'release');
+    const instantReleaseJob = getJobBlock(releaseWorkflow, 'instant-release');
+
+    expectMainWriterConcurrency(previewRegenJob);
+    expectMainWriterConcurrency(releaseJob);
+    expectMainWriterConcurrency(instantReleaseJob);
+    expect(previewRegenJob).toContain(
+      'bash scripts/push-main-with-rebase-retry.sh'
+    );
+    expect(previewRegenJob).not.toContain('git push origin HEAD:main');
+    expect(versionAndCommit).toContain(
+      'bash scripts/push-main-with-rebase-retry.sh'
+    );
+    expect(versionAndCommit).not.toContain('git push origin main');
+    expect(pushHelper).toContain('git push "$remote" "HEAD:$branch"');
+    expect(pushHelper).toContain('git pull --rebase "$remote" "$branch"');
   });
 
   it('verifies desktop package output before uploading artifacts', () => {


### PR DESCRIPTION
Fixes #98

## What

- Add `scripts/push-main-with-rebase-retry.sh`, which pushes `HEAD:main` and, on rejection, rebases on `origin/main` before retrying.
- Route preview image regeneration and release version commits through that helper.
- Serialize preview/release main-writing jobs with a shared `main-writer-${{ github.repository }}-main` concurrency group.
- Add a bare-remote regression test for the non-fast-forward race plus workflow wiring coverage.
- Add a patch changeset.

## Reproduction

`tests/push-main-with-rebase-retry.test.js` creates a bare Git remote and two clones: one clone commits generated preview output, another pushes a version-bump-style commit to `main` first, then the preview clone runs the helper. The test verifies the helper rebases, retries, and the remote keeps both commits.

## Testing

- `node --test --test-timeout=30000 tests/push-main-with-rebase-retry.test.js`
- `node --test --test-timeout=30000 tests/workflow-reliability.test.js`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`
- `npm test`
- `npm run check`
- `bun test --timeout 30000`
- `deno test --allow-read`
