### PR TITLE
fix: Quiet expected npm release checks

### DIFF
--- a/.changeset/quiet-npm-release-logs.md
+++ b/.changeset/quiet-npm-release-logs.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Quiet release logs by checking npm package versions through the registry HTTP API and removing deprecated setup-node `always-auth` config before publish-job npm commands run.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,6 +404,9 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Remove deprecated npm auth config
+        run: node scripts/sanitize-npm-userconfig.mjs
+
       - name: Install dependencies
         run: npm install
 
@@ -496,6 +499,9 @@ jobs:
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Remove deprecated npm auth config
+        run: node scripts/sanitize-npm-userconfig.mjs
 
       - name: Install dependencies
         run: npm install

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-03T16:06:40.352Z for PR creation at branch issue-97-26bb61723e63 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/97

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-03T16:06:40.352Z for PR creation at branch issue-97-26bb61723e63 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/97

--- a/scripts/check-release-needed.mjs
+++ b/scripts/check-release-needed.mjs
@@ -37,9 +37,9 @@
  */
 
 import { appendFileSync } from 'fs';
-import { execSync } from 'child_process';
 
 import { getJsRoot, parseJsRootConfig } from './js-paths.mjs';
+import { isPackageVersionPublished } from './npm-registry.mjs';
 import { readPackageInfo } from './package-info.mjs';
 
 const jsRootConfig = parseJsRootConfig();
@@ -70,21 +70,13 @@ function getPackageInfo() {
  * Check if a specific version is published on npm
  * @param {string} packageName
  * @param {string} version
- * @returns {boolean}
+ * @returns {Promise<boolean>}
  */
 function checkVersionOnNpm(packageName, version) {
-  try {
-    const result = execSync(`npm view "${packageName}@${version}" version`, {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return result.trim().includes(version);
-  } catch {
-    return false;
-  }
+  return isPackageVersionPublished(packageName, version);
 }
 
-function main() {
+async function main() {
   const hasChangesets = process.env.HAS_CHANGESETS === 'true';
   const { name: packageName, version: currentVersion } = getPackageInfo();
 
@@ -102,7 +94,7 @@ function main() {
   console.log(
     `Checking if ${packageName}@${currentVersion} is published on npm...`
   );
-  const isPublished = checkVersionOnNpm(packageName, currentVersion);
+  const isPublished = await checkVersionOnNpm(packageName, currentVersion);
   console.log(`Published on npm: ${isPublished}`);
 
   if (isPublished) {
@@ -120,4 +112,7 @@ function main() {
   }
 }
 
-main();
+main().catch((error) => {
+  console.error('Error:', error.message);
+  process.exit(1);
+});

--- a/scripts/npm-registry.mjs
+++ b/scripts/npm-registry.mjs
@@ -1,0 +1,97 @@
+export const DEFAULT_NPM_REGISTRY_URL = 'https://registry.npmjs.org';
+
+function getNpmRegistryFromEnv() {
+  try {
+    return process.env.NPM_CONFIG_REGISTRY || '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Normalize an npm registry URL so package metadata paths can be appended.
+ * @param {string} registryUrl
+ * @returns {string}
+ */
+export function normalizeRegistryUrl(
+  registryUrl = getNpmRegistryFromEnv() || DEFAULT_NPM_REGISTRY_URL
+) {
+  return String(registryUrl || DEFAULT_NPM_REGISTRY_URL).replace(/\/+$/, '');
+}
+
+/**
+ * Encode a package name for npm registry metadata URLs.
+ * @param {string} packageName
+ * @returns {string}
+ */
+export function encodePackageName(packageName) {
+  if (typeof packageName !== 'string' || packageName.trim() === '') {
+    throw new Error('Package name is required');
+  }
+
+  if (packageName.startsWith('@')) {
+    const [scope, name] = packageName.split('/');
+    if (!scope || !name) {
+      throw new Error(`Invalid scoped package name: ${packageName}`);
+    }
+    return `${scope}%2F${encodeURIComponent(name)}`;
+  }
+
+  return encodeURIComponent(packageName);
+}
+
+/**
+ * Build the npm registry package metadata URL.
+ * @param {string} packageName
+ * @param {string} registryUrl
+ * @returns {string}
+ */
+export function buildPackageMetadataUrl(
+  packageName,
+  registryUrl = getNpmRegistryFromEnv() || DEFAULT_NPM_REGISTRY_URL
+) {
+  return `${normalizeRegistryUrl(registryUrl)}/${encodePackageName(packageName)}`;
+}
+
+/**
+ * Check whether a package version exists in npm registry metadata.
+ * HTTP 404 means the package has not been published yet and is not an error.
+ * @param {string} packageName
+ * @param {string} version
+ * @param {object} options
+ * @param {Function} [options.fetchFn]
+ * @param {string} [options.registryUrl]
+ * @returns {Promise<boolean>}
+ */
+export async function isPackageVersionPublished(
+  packageName,
+  version,
+  {
+    fetchFn = fetch,
+    registryUrl = getNpmRegistryFromEnv() || DEFAULT_NPM_REGISTRY_URL,
+  } = {}
+) {
+  if (typeof version !== 'string' || version.trim() === '') {
+    throw new Error('Package version is required');
+  }
+
+  const metadataUrl = buildPackageMetadataUrl(packageName, registryUrl);
+  const response = await fetchFn(metadataUrl, {
+    headers: {
+      accept: 'application/json',
+    },
+  });
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch npm package metadata for ${packageName}: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const metadata = await response.json();
+  return Object.hasOwn(metadata?.versions || {}, version);
+}

--- a/scripts/publish-to-npm.mjs
+++ b/scripts/publish-to-npm.mjs
@@ -23,7 +23,8 @@
 import { appendFileSync } from 'fs';
 
 import { getJsRoot, needsCd, parseJsRootConfig } from './js-paths.mjs';
-import { formatNpmPackageVersion, readPackageInfo } from './package-info.mjs';
+import { isPackageVersionPublished } from './npm-registry.mjs';
+import { readPackageInfo } from './package-info.mjs';
 import {
   buildAuthFailureGuidance,
   isNonRetryableFailure,
@@ -108,19 +109,12 @@ function detectPublishFailure(output) {
 /**
  * Verify that a package version is published on npm
  * Reference: link-assistant/agent PR #116
- * @param {Function} shell
  * @param {string} packageName
  * @param {string} version
  * @returns {Promise<boolean>}
  */
-async function verifyPublished(shell, packageName, version) {
-  const result =
-    await shell`npm view "${formatNpmPackageVersion(packageName, version)}" version`.run(
-      {
-        capture: true,
-      }
-    );
-  return result.code === 0 && result.stdout.trim().includes(version);
+function verifyPublished(packageName, version) {
+  return isPackageVersionPublished(packageName, version);
 }
 
 /**
@@ -247,7 +241,7 @@ async function attemptPublish(
   // Verify the package is actually on npm (ultimate verification)
   console.log('Verifying package was published to npm...');
   await sleep(2000); // Wait for npm registry to propagate
-  const isPublished = await verifyPublished(shell, packageName, currentVersion);
+  const isPublished = await verifyPublished(packageName, currentVersion);
 
   if (isPublished) {
     return { success: true, error: null };
@@ -278,16 +272,12 @@ async function main() {
     console.log(
       `Checking if version ${currentVersion} is already published...`
     );
-    const checkResult =
-      await $`npm view "${formatNpmPackageVersion(packageName, currentVersion)}" version`.run(
-        {
-          capture: true,
-        }
-      );
+    const isAlreadyPublished = await isPackageVersionPublished(
+      packageName,
+      currentVersion
+    );
 
-    // command-stream returns { code: 0 } on success, { code: 1 } on failure (e.g., E404)
-    // Exit code 0 means version exists, non-zero means version not found
-    if (checkResult.code === 0) {
+    if (isAlreadyPublished) {
       console.log(`Version ${currentVersion} is already published to npm`);
       setOutput('published', 'true');
       setOutput('published_version', currentVersion);

--- a/scripts/sanitize-npm-userconfig.mjs
+++ b/scripts/sanitize-npm-userconfig.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const ALWAYS_AUTH_LINE = /^[^\S\r\n]*always-auth[^\S\r\n]*=.*(?:\r?\n|$)/gim;
+
+/**
+ * Remove deprecated always-auth entries from npmrc content.
+ * npm 11 warns about this key, while setup-node may still write it.
+ * @param {string} content
+ * @returns {{content: string, removed: boolean}}
+ */
+export function removeAlwaysAuthEntries(content) {
+  const sanitized = String(content).replace(ALWAYS_AUTH_LINE, '');
+  return {
+    content: sanitized,
+    removed: sanitized !== content,
+  };
+}
+
+/**
+ * Remove always-auth from the npm user config created by setup-node.
+ * @param {object} options
+ * @param {Record<string, string|undefined>} [options.env]
+ * @param {{log: Function, warn: Function}} [options.logger]
+ * @param {Function} [options.fileExists]
+ * @param {Function} [options.readFile]
+ * @param {Function} [options.writeFile]
+ * @returns {{path: string, removed: boolean, skipped: boolean}}
+ */
+export function sanitizeNpmUserConfig({
+  env = process.env,
+  logger = console,
+  fileExists = existsSync,
+  readFile = readFileSync,
+  writeFile = writeFileSync,
+} = {}) {
+  const userConfigPath = env.NPM_CONFIG_USERCONFIG || '';
+
+  if (!userConfigPath) {
+    logger.log(
+      'NPM_CONFIG_USERCONFIG is not set; no npm user config to clean.'
+    );
+    return { path: '', removed: false, skipped: true };
+  }
+
+  if (!fileExists(userConfigPath)) {
+    logger.warn(`npm user config does not exist: ${userConfigPath}`);
+    return { path: userConfigPath, removed: false, skipped: true };
+  }
+
+  const original = readFile(userConfigPath, 'utf8');
+  const result = removeAlwaysAuthEntries(original);
+
+  if (!result.removed) {
+    logger.log(`No deprecated always-auth entry found in ${userConfigPath}.`);
+    return { path: userConfigPath, removed: false, skipped: false };
+  }
+
+  writeFile(userConfigPath, result.content);
+  logger.log(`Removed deprecated always-auth entry from ${userConfigPath}.`);
+  return { path: userConfigPath, removed: true, skipped: false };
+}
+
+function isMainModule() {
+  return process.argv[1]
+    ? resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+    : false;
+}
+
+if (isMainModule()) {
+  sanitizeNpmUserConfig();
+}

--- a/tests/npm-registry.test.js
+++ b/tests/npm-registry.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'test-anywhere';
+import { readFileSync } from 'node:fs';
+
+import {
+  buildPackageMetadataUrl,
+  isPackageVersionPublished,
+} from '../scripts/npm-registry.mjs';
+
+function jsonResponse(status, body, statusText = 'OK') {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    async json() {
+      return body;
+    },
+  };
+}
+
+describe('npm registry package version checks', () => {
+  it('builds npm registry metadata URLs for scoped packages', () => {
+    expect(buildPackageMetadataUrl('@scope/real-package')).toBe(
+      'https://registry.npmjs.org/@scope%2Freal-package'
+    );
+  });
+
+  it('returns true when package metadata contains the requested version', async () => {
+    const isPublished = await isPackageVersionPublished(
+      '@scope/real-package',
+      '1.2.3',
+      {
+        fetchFn: async () =>
+          jsonResponse(200, {
+            versions: {
+              '1.2.3': {},
+            },
+          }),
+      }
+    );
+
+    expect(isPublished).toBe(true);
+  });
+
+  it('returns false for missing versions without throwing', async () => {
+    const isPublished = await isPackageVersionPublished(
+      '@scope/real-package',
+      '9.9.9',
+      {
+        fetchFn: async () =>
+          jsonResponse(200, {
+            versions: {
+              '1.2.3': {},
+            },
+          }),
+      }
+    );
+
+    expect(isPublished).toBe(false);
+  });
+
+  it('treats package 404 as an expected unpublished result', async () => {
+    const isPublished = await isPackageVersionPublished(
+      '@scope/missing-package',
+      '1.0.0',
+      {
+        fetchFn: async () => jsonResponse(404, {}, 'Not Found'),
+      }
+    );
+
+    expect(isPublished).toBe(false);
+  });
+
+  it('throws for unexpected registry failures', async () => {
+    let errorMessage = '';
+
+    try {
+      await isPackageVersionPublished('@scope/real-package', '1.2.3', {
+        fetchFn: async () => jsonResponse(500, {}, 'Server Error'),
+      });
+    } catch (error) {
+      errorMessage = error.message;
+    }
+
+    expect(errorMessage).toContain('500 Server Error');
+  });
+});
+
+describe('release npm registry usage', () => {
+  it('does not shell out to npm view for expected missing package versions', () => {
+    const publishScript = readFileSync('scripts/publish-to-npm.mjs', 'utf8');
+    const releaseCheckScript = readFileSync(
+      'scripts/check-release-needed.mjs',
+      'utf8'
+    );
+
+    expect(publishScript).not.toContain('npm view');
+    expect(releaseCheckScript).not.toContain('npm view');
+  });
+});

--- a/tests/sanitize-npm-userconfig.test.js
+++ b/tests/sanitize-npm-userconfig.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'test-anywhere';
+
+import {
+  removeAlwaysAuthEntries,
+  sanitizeNpmUserConfig,
+} from '../scripts/sanitize-npm-userconfig.mjs';
+
+const quietLogger = {
+  log() {},
+  warn() {},
+};
+
+describe('npm user config sanitization', () => {
+  it('removes only deprecated always-auth entries from npmrc content', () => {
+    const result = removeAlwaysAuthEntries(
+      [
+        '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}',
+        'always-auth=true',
+        'legacy-peer-deps=false',
+        '',
+      ].join('\n')
+    );
+
+    expect(result).toEqual({
+      content: [
+        '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}',
+        'legacy-peer-deps=false',
+        '',
+      ].join('\n'),
+      removed: true,
+    });
+  });
+
+  it('updates the user config file from NPM_CONFIG_USERCONFIG', () => {
+    const userConfigPath = '/tmp/.npmrc';
+    const files = new Map([
+      [
+        userConfigPath,
+        [
+          'always-auth=false',
+          '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}',
+          '',
+        ].join('\n'),
+      ],
+    ]);
+
+    const result = sanitizeNpmUserConfig({
+      env: { NPM_CONFIG_USERCONFIG: userConfigPath },
+      fileExists: (path) => files.has(path),
+      logger: quietLogger,
+      readFile: (path) => files.get(path),
+      writeFile: (path, content) => files.set(path, content),
+    });
+
+    expect(result).toEqual({
+      path: userConfigPath,
+      removed: true,
+      skipped: false,
+    });
+    expect(files.get(userConfigPath)).toBe(
+      ['//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}', ''].join('\n')
+    );
+  });
+
+  it('skips cleanly when setup-node did not create a user config file', () => {
+    const result = sanitizeNpmUserConfig({
+      env: {},
+      logger: quietLogger,
+    });
+
+    expect(result).toEqual({
+      path: '',
+      removed: false,
+      skipped: true,
+    });
+  });
+});

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -278,6 +278,22 @@ describe('npm publish token bootstrap', () => {
   }
 });
 
+describe('npm user config cleanup', () => {
+  for (const jobName of ['release', 'instant-release']) {
+    it(`removes deprecated always-auth before npm commands in the ${jobName} job`, () => {
+      const workflow = readWorkflow('.github/workflows/release.yml');
+      const job = getJobBlock(workflow, jobName);
+
+      expectOrdered(job, [
+        'uses: actions/setup-node@v6',
+        '- name: Remove deprecated npm auth config',
+        '- name: Install dependencies',
+      ]);
+      expect(job).toContain('run: node scripts/sanitize-npm-userconfig.mjs');
+    });
+  }
+});
+
 describe('install-from-package smoke test', () => {
   for (const jobName of ['release', 'instant-release']) {
     it(`smoke-tests the published npm package in the ${jobName} job`, () => {


### PR DESCRIPTION
## Summary

- Replace `npm view` release version checks with npm registry metadata lookups that treat HTTP 404 as an expected unpublished result.
- Remove deprecated setup-node `always-auth` config before the first npm command in release publishing jobs.
- Add regression coverage for registry checks, npm user config cleanup, workflow ordering, and the no-`npm view` release path.

## Reproduction and Verification

The new regression tests initially failed because the helper modules and workflow cleanup step were missing, and the release scripts still used `npm view` for expected misses.

Verified with:
- `node --test --test-timeout=30000 tests/npm-registry.test.js tests/sanitize-npm-userconfig.test.js tests/workflow-reliability.test.js`
- `npm test`
- `npm run check` (passes with existing warning-level lint findings, 0 errors)
- `bash scripts/check-mjs-syntax.sh`
- `deno test --allow-read`
- `bun test --timeout 30000`
- `GITHUB_BASE_REF=main GITHUB_BASE_SHA=$(git rev-parse origin/main) GITHUB_HEAD_SHA=$(git rev-parse HEAD) node scripts/validate-changeset.mjs`
- `HAS_CHANGESETS=false node scripts/check-release-needed.mjs`

Fixes #97