### PR TITLE
fix: Suppress checkout default branch warning

### DIFF
--- a/.changeset/quiet-checkout-default-branch.md
+++ b/.changeset/quiet-checkout-default-branch.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Suppress the Git default-branch hint during release workflow checkout.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ on:
         required: false
         type: string
 
+# Provide Git config to actions/checkout itself; checkout runs git init before
+# any workflow step can configure Git.
 env:
   GIT_CONFIG_COUNT: '1'
   GIT_CONFIG_KEY_0: init.defaultBranch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
 
+env:
+  GIT_CONFIG_COUNT: '1'
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 # Concurrency: Only one workflow run per branch at a time
 # - For main branch (releases): let runs finish so a newer push does not cancel
 #   an in-flight publish or release update.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-03T16:48:57.192Z for PR creation at branch issue-99-07063aba5237 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/99

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-03T16:48:57.192Z for PR creation at branch issue-99-07063aba5237 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/99

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -126,6 +126,25 @@ describe('workflow reliability policy', () => {
     }
   });
 
+  it('sets Git default branch config before checkout initializes repositories', () => {
+    const releaseWorkflow = readWorkflow('.github/workflows/release.yml');
+    const gitDefaultBranchEnv = [
+      'env:',
+      "  GIT_CONFIG_COUNT: '1'",
+      '  GIT_CONFIG_KEY_0: init.defaultBranch',
+      '  GIT_CONFIG_VALUE_0: main',
+    ].join('\n');
+
+    expect(releaseWorkflow).toContain(gitDefaultBranchEnv);
+    expectOrdered(releaseWorkflow, [
+      'workflow_dispatch:',
+      gitDefaultBranchEnv,
+      'concurrency:',
+      'jobs:',
+      '- uses: actions/checkout@v6',
+    ]);
+  });
+
   it('excludes Vite source HTML from raw lychee file scans', () => {
     const linksWorkflow = readWorkflow('.github/workflows/links.yml');
     const viteSourceHtmlPath = 'examples/universal-app/index.html';


### PR DESCRIPTION
## What
- Added workflow-level Git runtime config in `.github/workflows/release.yml` so `actions/checkout@v6` receives `init.defaultBranch=main` before it runs `git init`.
- Added a workflow contract test that preserves the top-level env block.
- Added a patch changeset for the workflow reliability fix.

## Why
`actions/checkout@v6` initializes the repository before normal workflow steps can run, so setting Git config in a later shell step cannot suppress the Git default-branch hint.

## Reproduction
Before the fix, `node --test --test-timeout=30000 tests/workflow-reliability.test.js` failed on `sets Git default branch config before checkout initializes repositories`.

## Verification
- `node --test --test-timeout=30000 tests/workflow-reliability.test.js`
- `npm test`
- `npm run check`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`
- `bash scripts/check-file-line-limits.sh`
- `bash scripts/check-mjs-syntax.sh`

Fixes #99