### PR TITLE
ci: default workflows to least-privilege GITHUB_TOKEN scope

### DIFF
--- a/.changeset/tidy-tokens-rest.md
+++ b/.changeset/tidy-tokens-rest.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Add a least-privilege top-level `permissions: contents: read` block to `release.yml` and `links.yml` so jobs no longer inherit the repository default `GITHUB_TOKEN` scope, with write access escalated only on the publishing jobs.

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -25,6 +25,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Least-privilege default; jobs escalate individually when needed.
+permissions:
+  contents: read
+
 jobs:
   link-checker:
     name: Check Links

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
 
+# Least-privilege default for the highest-value token in the repository.
+# Every job starts read-only; the publishing jobs escalate individually.
+permissions:
+  contents: read
+
 # Provide Git config to actions/checkout itself; checkout runs git init before
 # any workflow step can configure Git.
 env:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-20T10:47:17.147Z for PR creation at branch issue-104-fea61a10d5f1 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/104

--- a/tests/workflow-permissions.test.js
+++ b/tests/workflow-permissions.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'test-anywhere';
+import { readdirSync, readFileSync } from 'node:fs';
+
+const WORKFLOW_DIR = '.github/workflows';
+
+function readWorkflow(fileName) {
+  return readFileSync(`${WORKFLOW_DIR}/${fileName}`, 'utf8').replaceAll(
+    '\r\n',
+    '\n'
+  );
+}
+
+function listWorkflowFiles() {
+  return readdirSync(WORKFLOW_DIR).filter((file) => /\.ya?ml$/.test(file));
+}
+
+// Returns the top-level `permissions:` block body, or undefined when the
+// workflow has none (in which case jobs inherit the repository default,
+// which is read/write-all on many organisations).
+function getTopLevelPermissions(workflow) {
+  const lines = workflow.split('\n');
+  const start = lines.indexOf('permissions:');
+
+  if (start === -1) {
+    return undefined;
+  }
+
+  const end = lines.findIndex(
+    (line, index) => index > start && line !== '' && !line.startsWith('  ')
+  );
+
+  return lines
+    .slice(start + 1, end === -1 ? lines.length : end)
+    .filter((line) => line.trim() !== '')
+    .join('\n');
+}
+
+describe('workflow token permissions', () => {
+  it('declares a top-level permissions block in every workflow', () => {
+    const missing = listWorkflowFiles().filter(
+      (file) => getTopLevelPermissions(readWorkflow(file)) === undefined
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it('defaults release.yml to read-only repository contents', () => {
+    const permissions = getTopLevelPermissions(readWorkflow('release.yml'));
+
+    expect(permissions).toBe('  contents: read');
+  });
+
+  it('keeps write escalation on the publishing jobs only', () => {
+    const workflow = readWorkflow('release.yml');
+    const jobsBody = workflow.slice(workflow.indexOf('\njobs:\n'));
+
+    for (const job of ['release', 'instant-release', 'changeset-pr']) {
+      const start = jobsBody.indexOf(`\n  ${job}:\n`);
+      expect(start).not.toBe(-1);
+
+      const rest = jobsBody.slice(start + 1);
+      const end = rest.search(/\n {2}[a-zA-Z0-9_-]+:\n/);
+      const block = end === -1 ? rest : rest.slice(0, end);
+
+      expect(block.includes('      contents: write')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #104.

`.github/workflows/release.yml` had no top-level `permissions:` block, so every job inherited the repository default `GITHUB_TOKEN` scope — read/write-all on organisations that have not changed the default. That is the highest-value token in the repository: it publishes packages, pushes tags and commits, and creates releases.

## Changes

- `release.yml`: added top-level `permissions: contents: read`. The `release`, `instant-release` and `changeset-pr` jobs already declare their own escalation (`contents: write`, `pull-requests: write`, `id-token: write`), so publishing is unaffected; every other job now runs read-only.
- `links.yml`: same top-level default for defence in depth (its single job already scoped itself to `contents: read`).
- `tests/workflow-permissions.test.js`: new regression test that fails if any workflow lacks a top-level `permissions:` block, if `release.yml`'s default is anything other than `contents: read`, or if the publishing jobs lose their `contents: write` escalation.

## Reproduction / verification

Before the fix:

```bash
grep -n '^permissions:' .github/workflows/release.yml || echo "NONE"   # -> NONE
```

The new test reproduces the same check in CI. It fails on the pre-fix file and passes now:

```
npm test  # 159 tests, 0 failures
```

`npm run lint` and `npm run format:check` are clean (only pre-existing warnings).