### PR TITLE
ci: build Dockerfile on pull requests so a broken image fails the PR

### DIFF
--- a/.changeset/docker-pr-build-check.md
+++ b/.changeset/docker-pr-build-check.md
@@ -1,0 +1,5 @@
+---
+'js-ai-driven-development-pipeline-template': patch
+---
+
+Build the Dockerfile on pull requests via a new `docker-build` job, so a broken image fails the pull request instead of only surfacing after the package is published. The build uses `push: false` with `load: true` (works for fork pull requests, which have no registry credentials) and the GHA layer cache. Repositories without a Dockerfile skip the job automatically.

--- a/.changeset/docker-pr-build-check.md
+++ b/.changeset/docker-pr-build-check.md
@@ -1,5 +1,5 @@
 ---
-'js-ai-driven-development-pipeline-template': patch
+'@link-foundation/example-package-name': patch
 ---
 
 Build the Dockerfile on pull requests via a new `docker-build` job, so a broken image fails the pull request instead of only surfacing after the package is published. The build uses `push: false` with `load: true` (works for fork pull requests, which have no registry credentials) and the GHA layer cache. Repositories without a Dockerfile skip the job automatically.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,6 +328,47 @@ jobs:
         if: matrix.runtime == 'deno'
         run: deno test --allow-read
 
+  # === DOCKER IMAGE BUILD CHECK (pull requests) ===
+  # Builds the Dockerfile without pushing so a broken image fails the pull
+  # request instead of surfacing only after publish (issue #106).
+  # push: false + load: true keeps this working for fork pull requests,
+  # which have no registry credentials. Skipped when no Dockerfile exists.
+  docker-build:
+    name: Docker Image Build Check
+    runs-on: ubuntu-latest
+    # Typical run: a few minutes with a warm GHA layer cache. 30min covers
+    # a cold, uncached build without allowing a 6h hang.
+    timeout-minutes: 30
+    needs: [detect-changes]
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
+    permissions:
+      contents: read
+    env:
+      DOCKER_CONTEXT: ${{ vars.DOCKER_CONTEXT }}
+      DOCKERFILE: ${{ vars.DOCKERFILE }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check Docker build configuration
+        id: docker_config
+        run: node scripts/check-docker-build.mjs
+
+      - name: Set up Docker Buildx (resilient)
+        if: steps.docker_config.outputs.enabled == 'true'
+        uses: ./.github/actions/setup-buildx-resilient
+
+      - name: Build Docker image (no push)
+        if: steps.docker_config.outputs.enabled == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ steps.docker_config.outputs.context }}
+          file: ${{ steps.docker_config.outputs.dockerfile }}
+          push: false
+          load: true
+          tags: pr-check:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   # === DOCUMENTATION VALIDATION ===
   # Validate documentation files when docs change (hive-mind principle #12)
   validate-docs:

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106

--- a/scripts/check-docker-build.mjs
+++ b/scripts/check-docker-build.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+/**
+ * Decide whether the pull-request Docker build check should run.
+ *
+ * The publish path (scripts/check-docker-publish.mjs) requires registry
+ * credentials, which fork pull requests never have. The build check only
+ * needs a Dockerfile: when the repository ships one, every pull request
+ * builds it, so a Dockerfile regression fails the pull request before the
+ * package is published.
+ *
+ * - DOCKERFILE: Dockerfile path (optional, defaults to ./Dockerfile)
+ * - DOCKER_CONTEXT: build context path (optional, defaults to .)
+ */
+
+import { appendFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_CONTEXT = '.';
+const DEFAULT_DOCKERFILE = './Dockerfile';
+
+function clean(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function evaluateDockerBuildConfig({
+  cwd = process.cwd(),
+  env = process.env,
+} = {}) {
+  const context = clean(env.DOCKER_CONTEXT) || DEFAULT_CONTEXT;
+  const dockerfile = clean(env.DOCKERFILE) || DEFAULT_DOCKERFILE;
+  const errors = [];
+
+  const dockerfileExists = existsSync(path.resolve(cwd, dockerfile));
+  const contextExists = existsSync(path.resolve(cwd, context));
+
+  // Repositories without a Dockerfile skip the check; this is not an error.
+  if (!dockerfileExists) {
+    return {
+      context,
+      dockerfile,
+      enabled: false,
+      errors,
+    };
+  }
+
+  if (!contextExists) {
+    errors.push(`Docker context does not exist: ${context}`);
+  }
+
+  return {
+    context,
+    dockerfile,
+    enabled: errors.length === 0,
+    errors,
+  };
+}
+
+function setOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) {
+    appendFileSync(outputFile, `${name}=${value}\n`);
+  }
+  console.log(`Output: ${name}=${value}`);
+}
+
+function isCliEntryPoint() {
+  return (
+    typeof process !== 'undefined' &&
+    process.argv?.[1] &&
+    fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  );
+}
+
+export function main({ env = process.env, stderr = console.error } = {}) {
+  const config = evaluateDockerBuildConfig({ env });
+
+  setOutput('enabled', config.enabled ? 'true' : 'false');
+  setOutput('context', config.context);
+  setOutput('dockerfile', config.dockerfile);
+
+  if (config.errors.length > 0) {
+    for (const error of config.errors) {
+      stderr(`::error::${error}`);
+    }
+    return 1;
+  }
+
+  if (!config.enabled) {
+    console.log(
+      `Docker build check is skipped: no Dockerfile at ${config.dockerfile}`
+    );
+    return 0;
+  }
+
+  console.log(`Docker build check is enabled for ${config.dockerfile}`);
+  return 0;
+}
+
+if (isCliEntryPoint()) {
+  process.exitCode = main();
+}

--- a/tests/ci-timeouts.test.js
+++ b/tests/ci-timeouts.test.js
@@ -58,6 +58,7 @@ describe('CI timeout policy', () => {
       'validate-docs': 5,
       release: 30,
       'instant-release': 30,
+      'docker-build': 30,
       'docker-publish': 30,
       'changeset-pr': 10,
     };

--- a/tests/docker-build.test.js
+++ b/tests/docker-build.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'test-anywhere';
+import { readFileSync } from 'node:fs';
+
+import { evaluateDockerBuildConfig } from '../scripts/check-docker-build.mjs';
+
+const releaseWorkflow = readFileSync(
+  '.github/workflows/release.yml',
+  'utf8'
+).replaceAll('\r\n', '\n');
+
+function getWorkflowJob(workflow, jobName) {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex((line) => line === `  ${jobName}:`);
+  if (start === -1) {
+    return '';
+  }
+
+  const nextJob = lines.findIndex(
+    (line, index) => index > start && /^[ ]{2}[a-zA-Z0-9_-]+:\s*$/.test(line)
+  );
+  return lines.slice(start, nextJob === -1 ? lines.length : nextJob).join('\n');
+}
+
+describe('pull-request Docker build check', () => {
+  const dockerBuildJob = getWorkflowJob(releaseWorkflow, 'docker-build');
+
+  it('runs on pull requests with code changes', () => {
+    expect(dockerBuildJob).not.toBe('');
+    expect(dockerBuildJob).toContain('needs: [detect-changes]');
+    expect(dockerBuildJob).toContain(
+      "if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'"
+    );
+    expect(dockerBuildJob).toContain('timeout-minutes:');
+  });
+
+  it('builds without pushing so fork pull requests work without credentials', () => {
+    expect(dockerBuildJob).toContain('uses: docker/build-push-action@v7');
+    expect(dockerBuildJob).toContain('push: false');
+    expect(dockerBuildJob).toContain('load: true');
+    expect(dockerBuildJob).toContain('cache-from: type=gha');
+    expect(dockerBuildJob).toContain('cache-to: type=gha,mode=max');
+    expect(dockerBuildJob).not.toContain('DOCKERHUB_TOKEN');
+  });
+
+  it('builds the image before any release job runs', () => {
+    // The publish job is gated on a successful release; the build check
+    // must not be, otherwise a broken Dockerfile cannot fail a PR.
+    const publishJob = getWorkflowJob(releaseWorkflow, 'docker-publish');
+    expect(publishJob).toContain('needs: [release, instant-release]');
+    expect(dockerBuildJob).not.toContain('release');
+  });
+});
+
+describe('Docker build configuration', () => {
+  it('stays disabled when the repository ships no Dockerfile', () => {
+    const config = evaluateDockerBuildConfig({ cwd: '.', env: {} });
+
+    expect(config.enabled).toBe(false);
+    expect(config.errors).toEqual([]);
+    expect(config.dockerfile).toBe('./Dockerfile');
+    expect(config.context).toBe('.');
+  });
+
+  it('enables the build when a Dockerfile exists', () => {
+    const config = evaluateDockerBuildConfig({
+      cwd: '.',
+      env: { DOCKERFILE: 'package.json', DOCKER_CONTEXT: '.' },
+    });
+
+    expect(config).toEqual({
+      context: '.',
+      dockerfile: 'package.json',
+      enabled: true,
+      errors: [],
+    });
+  });
+
+  it('reports a missing build context', () => {
+    const config = evaluateDockerBuildConfig({
+      cwd: '.',
+      env: { DOCKERFILE: 'package.json', DOCKER_CONTEXT: 'does-not-exist' },
+    });
+
+    expect(config.enabled).toBe(false);
+    expect(config.errors).toEqual([
+      'Docker context does not exist: does-not-exist',
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #106

## Problem

`docker-publish` (`.github/workflows/release.yml`) is gated on `needs: [release, instant-release]` with `published == 'true'`, so the image is only ever built **after** the package is published. A Dockerfile regression cannot fail a pull request; it produces a half-finished release (package published, no image).

## Solution

New `docker-build` job that runs on pull requests with code changes, before any release job:

- `push: false` + `load: true` — works for fork pull requests, which have no registry credentials (`DOCKERHUB_TOKEN` is never referenced by this job).
- `cache-from/cache-to: type=gha` — shares the buildx layer cache with the publish build.
- `timeout-minutes: 30`, matching `docker-publish`.
- Reuses the existing `./.github/actions/setup-buildx-resilient` action.

Because this template ships no Dockerfile by default, `scripts/check-docker-build.mjs` gates the build steps: no Dockerfile → the job succeeds as a no-op; Dockerfile present (path overridable via `vars.DOCKERFILE` / `vars.DOCKER_CONTEXT`, same variables the publish path uses) → the image is built. A missing build context is a hard error.

## Tests

`tests/docker-build.test.js` (new, 6 cases):
- the workflow job exists, needs `detect-changes`, is PR-gated, and has a timeout;
- it builds with `push: false` / `load: true` / GHA cache and never references `DOCKERHUB_TOKEN`;
- it is not gated on the release jobs (the regression this issue reports);
- config evaluation: disabled with no Dockerfile (no error), enabled with one, error on a missing context.

`tests/ci-timeouts.test.js` updated with the new job's expected timeout.

Full suite: 162 tests passing across the node/bun/deno matrix locally; eslint + prettier clean. A changeset is included.