### PR TITLE
fix(publish): poll npm registry for verification instead of republishing

### DIFF
--- a/.changeset/publish-verification-polling.md
+++ b/.changeset/publish-verification-polling.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Split publish and verification failure domains in `publish-to-npm.mjs`: verification now polls the npm registry with exponential backoff, and a verification miss no longer re-runs `changeset publish`.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-07-20T10:47:17.147Z for PR creation at branch issue-104-fea61a10d5f1 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/104
+# Updated: 2026-07-20T11:05:28.272Z

--- a/scripts/publish-retry.mjs
+++ b/scripts/publish-retry.mjs
@@ -1,0 +1,201 @@
+/**
+ * Publish orchestration helpers that keep the two failure domains separate:
+ *
+ * - the publish command itself failing (retryable: run `changeset publish` again)
+ * - post-publish verification missing because the npm registry has not
+ *   propagated yet (NOT retryable by republishing: the only correct response is
+ *   to look again)
+ *
+ * A single verification check a couple of seconds after a successful publish
+ * samples a race: when it misses, republishing fails with "cannot publish over
+ * the previously published versions" and a successful release is reported as a
+ * failure.
+ */
+
+export const DEFAULT_VERIFY_ATTEMPTS = 7;
+export const DEFAULT_VERIFY_INITIAL_DELAY = 2000;
+export const DEFAULT_VERIFY_MAX_DELAY = 30000;
+
+/**
+ * Default sleep implementation.
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+export function sleep(ms) {
+  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
+}
+
+/**
+ * Patterns that mean "this exact version is already on the registry".
+ * Such an error is a cue to verify, not to fail.
+ */
+const ALREADY_PUBLISHED_PATTERNS = [
+  'epublishconflict',
+  'cannot publish over the previously published version',
+  'cannot publish over previously published version',
+  'you cannot publish over the previously published versions',
+  'already published',
+];
+
+/**
+ * Check whether publish output indicates the version is already published.
+ * @param {string} output
+ * @returns {boolean}
+ */
+export function isAlreadyPublishedError(output) {
+  const lowerOutput = String(output || '').toLowerCase();
+  return ALREADY_PUBLISHED_PATTERNS.some((pattern) =>
+    lowerOutput.includes(pattern)
+  );
+}
+
+/**
+ * Poll the registry until the version becomes visible, using exponential
+ * backoff. Returns true as soon as the version is found.
+ * @param {object} options
+ * @param {Function} options.verify - async () => boolean
+ * @param {number} [options.attempts]
+ * @param {number} [options.initialDelay]
+ * @param {number} [options.maxDelay]
+ * @param {Function} [options.sleepFn]
+ * @param {Function} [options.log]
+ * @returns {Promise<boolean>}
+ */
+export async function waitForVersionOnRegistry({
+  verify,
+  attempts = DEFAULT_VERIFY_ATTEMPTS,
+  initialDelay = DEFAULT_VERIFY_INITIAL_DELAY,
+  maxDelay = DEFAULT_VERIFY_MAX_DELAY,
+  sleepFn = sleep,
+  log = () => {},
+}) {
+  let delay = initialDelay;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    await sleepFn(delay);
+    let found = false;
+    try {
+      found = await verify();
+    } catch (error) {
+      // A transient registry/network error is indistinguishable from a miss
+      // here, so polling continues and the release is not failed at this point.
+      log(`Verification attempt ${attempt} errored: ${error.message}`);
+    }
+    if (found) {
+      log(`Verification succeeded on attempt ${attempt}`);
+      return true;
+    }
+    log(
+      `Verification attempt ${attempt} of ${attempts}: version not visible yet`
+    );
+    delay = Math.min(delay * 2, maxDelay);
+  }
+  return false;
+}
+
+/**
+ * Decide whether a publish invocation should move on to verification.
+ * @param {object} outcome
+ * @param {boolean} outcome.success
+ * @param {Error} [outcome.error]
+ * @param {string} [outcome.output]
+ * @param {Function} outcome.log
+ * @returns {boolean}
+ */
+function shouldVerify({ success, error, output, log }) {
+  if (success) {
+    return true;
+  }
+  if (!isAlreadyPublishedError(output || error?.message || '')) {
+    return false;
+  }
+  log('Publish reported the version is already published, verifying registry.');
+  return true;
+}
+
+/**
+ * Build the result of the verification stage. A verification miss is terminal:
+ * the publish path must not be re-entered, because the package may already be
+ * live and republishing would fail with a conflict.
+ * @param {boolean} verified
+ * @returns {{success: boolean, error: Error|null}}
+ */
+function verificationOutcome(verified) {
+  if (verified) {
+    return { success: true, error: null };
+  }
+  const error = new Error(
+    'Package not found on npm after publish; verification polling exhausted'
+  );
+  error.nonRetryable = true;
+  error.verificationFailed = true;
+  return { success: false, error };
+}
+
+/**
+ * Run the publish command with retries, then verify with bounded polling.
+ *
+ * The publish command is retried only when the publish itself failed. Once a
+ * publish reports success (or reports an "already published" conflict), the
+ * flow moves to verification and never re-enters the publish path.
+ *
+ * Verification is still required: a publish that falsely claims success still
+ * fails the release.
+ *
+ * @param {object} options
+ * @param {Function} options.publish - async () => ({ success, error, output })
+ * @param {Function} options.verify - async () => boolean
+ * @param {number} [options.maxRetries]
+ * @param {number} [options.retryDelay]
+ * @param {Function} [options.sleepFn]
+ * @param {Function} [options.log]
+ * @param {object} [options.verifyOptions]
+ * @returns {Promise<{success: boolean, error: Error|null, publishAttempts: number}>}
+ */
+export async function publishWithRetry({
+  publish,
+  verify,
+  maxRetries = 3,
+  retryDelay = 10000,
+  sleepFn = sleep,
+  log = () => {},
+  verifyOptions = {},
+}) {
+  let publishAttempts = 0;
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    log(`Publish attempt ${attempt} of ${maxRetries}...`);
+    publishAttempts++;
+    const { success, error, output } = await publish();
+
+    if (shouldVerify({ success, error, output, log })) {
+      const verified = await waitForVersionOnRegistry({
+        verify,
+        sleepFn,
+        log,
+        ...verifyOptions,
+      });
+      return { ...verificationOutcome(verified), publishAttempts };
+    }
+
+    lastError = error;
+
+    if (error?.nonRetryable) {
+      return { success: false, error, publishAttempts };
+    }
+
+    if (attempt < maxRetries) {
+      log(
+        `Publish failed: ${error?.message}, waiting ${retryDelay / 1000}s before retry...`
+      );
+      await sleepFn(retryDelay);
+    }
+  }
+
+  return {
+    success: false,
+    error:
+      lastError || new Error(`Failed to publish after ${maxRetries} attempts`),
+    publishAttempts,
+  };
+}

--- a/scripts/publish-to-npm.mjs
+++ b/scripts/publish-to-npm.mjs
@@ -14,10 +14,8 @@
  * - command-stream: Modern shell command execution with streaming support
  * - lino-arguments: Unified configuration from CLI args, env vars, and .lenv files
  *
- * Addresses issues documented in:
- * - Issue #21: Supporting both single and multi-language repository structures
- * - Reference: link-assistant/agent PR #112 (--legacy-peer-deps fix)
- * - Reference: link-assistant/agent PR #114 (configurable package root)
+ * Supports both single and multi-language repository structures via a
+ * configurable package root.
  */
 
 import { appendFileSync } from 'fs';
@@ -29,6 +27,11 @@ import {
   buildAuthFailureGuidance,
   isNonRetryableFailure,
 } from './publish-failure-classifier.mjs';
+import {
+  isAlreadyPublishedError,
+  publishWithRetry,
+  sleep,
+} from './publish-retry.mjs';
 
 // Load use-m dynamically
 const { use } = eval(
@@ -70,7 +73,7 @@ const RETRY_DELAY = 10000; // 10 seconds
 const originalCwd = process.cwd();
 
 // Patterns that indicate publish failure in changeset output
-// Reference: link-assistant/agent PR #116 - prevent false positives in CI/CD
+// Guards against false positives in CI/CD output parsing.
 const FAILURE_PATTERNS = [
   'packages failed to publish',
   'error occurred while publishing',
@@ -83,16 +86,7 @@ const FAILURE_PATTERNS = [
 ];
 
 /**
- * Sleep for specified milliseconds
- * @param {number} ms
- */
-function sleep(ms) {
-  return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
-}
-
-/**
  * Check if the output contains any failure patterns
- * Reference: link-assistant/agent PR #116
  * @param {string} output - Combined stdout and stderr
  * @returns {string|null} - The matched failure pattern or null if no failure detected
  */
@@ -108,7 +102,6 @@ function detectPublishFailure(output) {
 
 /**
  * Verify that a package version is published on npm
- * Reference: link-assistant/agent PR #116
  * @param {string} packageName
  * @param {string} version
  * @returns {Promise<boolean>}
@@ -165,7 +158,6 @@ async function runChangesetPublish(shell, jsRoot, originalCwd) {
 
 /**
  * Analyze publish result for failures using multi-layer detection
- * Reference: link-assistant/agent PR #116
  * @param {object|null} publishResult - The result from runChangesetPublish
  * @param {Error|null} commandError - Error thrown by the command
  * @returns {Error|null} - Error if failure detected, null otherwise
@@ -201,57 +193,37 @@ function analyzePublishResult(publishResult, commandError) {
 }
 
 /**
- * Perform a single publish attempt with verification
- * @param {string} currentVersion
- * @param {string} packageName
+ * Run a single publish command invocation (no verification).
+ * Verification is a separate failure domain handled by publishWithRetry.
  * @param {Function} shell
  * @param {string} jsRoot
  * @param {string} originalCwd
- * @returns {Promise<{success: boolean, error: Error|null}>}
+ * @returns {Promise<{success: boolean, error: Error|null, output: string}>}
  */
-async function attemptPublish(
-  currentVersion,
-  packageName,
-  shell,
-  jsRoot,
-  originalCwd
-) {
+async function runPublishCommand(shell, jsRoot, originalCwd) {
   const { result, error } = await runChangesetPublish(
     shell,
     jsRoot,
     originalCwd
   );
   const analysisError = analyzePublishResult(result, error);
+  const output = [
+    analysisError?.message || '',
+    result?.stdout || '',
+    result?.stderr || '',
+  ].join('\n');
 
   if (analysisError) {
     // Mark authentication / registry-configuration failures as non-retryable so
-    // the retry loop can fail fast with actionable guidance instead of burning
-    // through MAX_RETRIES (issue #77).
-    const combinedOutput = [
-      analysisError.message || '',
-      result?.stdout || '',
-      result?.stderr || '',
-    ].join('\n');
-    if (isNonRetryableFailure(combinedOutput)) {
+    // the retry loop can fail fast with actionable guidance without burning
+    // through MAX_RETRIES.
+    if (!isAlreadyPublishedError(output) && isNonRetryableFailure(output)) {
       analysisError.nonRetryable = true;
     }
-    return { success: false, error: analysisError };
+    return { success: false, error: analysisError, output };
   }
 
-  // Verify the package is actually on npm (ultimate verification)
-  console.log('Verifying package was published to npm...');
-  await sleep(2000); // Wait for npm registry to propagate
-  const isPublished = await verifyPublished(packageName, currentVersion);
-
-  if (isPublished) {
-    return { success: true, error: null };
-  }
-
-  console.error('Verification failed: package not found on npm after publish');
-  return {
-    success: false,
-    error: new Error('Package not found on npm after publish attempt'),
-  };
+  return { success: true, error: null, output };
 }
 
 async function main() {
@@ -291,43 +263,34 @@ async function main() {
     );
 
     // Publish to npm using OIDC trusted publishing with retry logic
-    // Multi-layer failure detection based on link-assistant/agent PR #116
-    for (let i = 1; i <= MAX_RETRIES; i++) {
-      console.log(`Publish attempt ${i} of ${MAX_RETRIES}...`);
-      const { success, error } = await attemptPublish(
-        currentVersion,
-        packageName,
-        $,
-        jsRoot,
-        originalCwd
-      );
+    // Multi-layer failure detection guards against a publish command that
+    // reports success without actually publishing.
+    //
+    // The publish command is retried only when the publish itself failed.
+    // A verification miss is handled by bounded polling and never triggers a
+    // republish.
+    const { success, error } = await publishWithRetry({
+      publish: () => runPublishCommand($, jsRoot, originalCwd),
+      verify: () => verifyPublished(packageName, currentVersion),
+      maxRetries: MAX_RETRIES,
+      retryDelay: RETRY_DELAY,
+      sleepFn: sleep,
+      log: (message) => console.log(message),
+    });
 
-      if (success) {
-        setOutput('published', 'true');
-        setOutput('published_version', currentVersion);
-        console.log(`\u2705 Published ${packageName}@${currentVersion} to npm`);
-        return;
-      }
-
-      // Authentication / registry-configuration errors will not be fixed by
-      // retrying, so fail fast with actionable guidance instead of burning
-      // through MAX_RETRIES (which previously hid the real cause behind a
-      // generic "Failed to publish after 3 attempts" message). See issue #77.
-      if (error?.nonRetryable) {
-        console.error(`Publish failed: ${error.message}`);
-        console.error(buildAuthFailureGuidance(packageName));
-        process.exit(1);
-      }
-
-      if (i < MAX_RETRIES) {
-        console.log(
-          `Publish failed: ${error.message}, waiting ${RETRY_DELAY / 1000}s before retry...`
-        );
-        await sleep(RETRY_DELAY);
-      }
+    if (success) {
+      setOutput('published', 'true');
+      setOutput('published_version', currentVersion);
+      console.log(`\u2705 Published ${packageName}@${currentVersion} to npm`);
+      return;
     }
 
-    console.error(`\u274C Failed to publish after ${MAX_RETRIES} attempts`);
+    console.error(`\u274C Publish failed: ${error.message}`);
+    // Authentication / registry-configuration errors will not be fixed by
+    // retrying, so print actionable guidance for the operator.
+    if (error?.nonRetryable && !error?.verificationFailed) {
+      console.error(buildAuthFailureGuidance(packageName));
+    }
     process.exit(1);
   } catch (error) {
     // Restore cwd on error

--- a/tests/publish-retry.test.js
+++ b/tests/publish-retry.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'test-anywhere';
+
+import {
+  isAlreadyPublishedError,
+  publishWithRetry,
+  waitForVersionOnRegistry,
+} from '../scripts/publish-retry.mjs';
+
+const noSleep = async () => {};
+
+describe('waitForVersionOnRegistry', () => {
+  it('returns true as soon as the version becomes visible', async () => {
+    let checks = 0;
+    const found = await waitForVersionOnRegistry({
+      verify: async () => ++checks >= 3,
+      sleepFn: noSleep,
+    });
+    expect(found).toBe(true);
+    expect(checks).toBe(3);
+  });
+
+  it('keeps polling when verification throws (E404 propagation lag)', async () => {
+    let checks = 0;
+    const found = await waitForVersionOnRegistry({
+      verify: async () => {
+        if (++checks < 3) {
+          throw new Error('npm error code E404');
+        }
+        return true;
+      },
+      sleepFn: noSleep,
+    });
+    expect(found).toBe(true);
+  });
+
+  it('returns false after exhausting the bounded attempts', async () => {
+    let checks = 0;
+    const found = await waitForVersionOnRegistry({
+      verify: async () => {
+        checks++;
+        return false;
+      },
+      attempts: 4,
+      sleepFn: noSleep,
+    });
+    expect(found).toBe(false);
+    expect(checks).toBe(4);
+  });
+
+  it('uses exponential backoff capped at maxDelay', async () => {
+    const delays = [];
+    await waitForVersionOnRegistry({
+      verify: async () => false,
+      attempts: 5,
+      initialDelay: 2000,
+      maxDelay: 8000,
+      sleepFn: async (ms) => {
+        delays.push(ms);
+      },
+    });
+    expect(delays).toEqual([2000, 4000, 8000, 8000, 8000]);
+  });
+});
+
+describe('isAlreadyPublishedError', () => {
+  it('detects publish conflicts', () => {
+    expect(
+      isAlreadyPublishedError(
+        'You cannot publish over the previously published versions: 1.0.0.'
+      )
+    ).toBe(true);
+    expect(isAlreadyPublishedError('npm error code EPUBLISHCONFLICT')).toBe(
+      true
+    );
+    expect(isAlreadyPublishedError('npm error code E401')).toBe(false);
+    expect(isAlreadyPublishedError(undefined)).toBe(false);
+  });
+});
+
+describe('publishWithRetry', () => {
+  it('never republishes when only verification lags', async () => {
+    let publishes = 0;
+    let checks = 0;
+    const result = await publishWithRetry({
+      publish: async () => {
+        publishes++;
+        if (publishes > 1) {
+          return {
+            success: false,
+            error: new Error(
+              'cannot publish over the previously published versions'
+            ),
+            output: 'cannot publish over the previously published versions',
+          };
+        }
+        return { success: true, error: null, output: 'success' };
+      },
+      verify: async () => {
+        if (++checks < 3) {
+          throw new Error('npm error code E404');
+        }
+        return true;
+      },
+      sleepFn: noSleep,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.publishAttempts).toBe(1);
+    expect(publishes).toBe(1);
+  });
+
+  it('fails without republishing when verification polling is exhausted', async () => {
+    let publishes = 0;
+    const result = await publishWithRetry({
+      publish: async () => {
+        publishes++;
+        return { success: true, error: null, output: 'success' };
+      },
+      verify: async () => false,
+      verifyOptions: { attempts: 3 },
+      sleepFn: noSleep,
+    });
+
+    expect(result.success).toBe(false);
+    expect(publishes).toBe(1);
+    expect(result.error.verificationFailed).toBe(true);
+  });
+
+  it('retries the publish command when the publish itself failed', async () => {
+    let publishes = 0;
+    const result = await publishWithRetry({
+      publish: async () => {
+        publishes++;
+        if (publishes < 3) {
+          return {
+            success: false,
+            error: new Error('network error'),
+            output: 'network error',
+          };
+        }
+        return { success: true, error: null, output: 'success' };
+      },
+      verify: async () => true,
+      sleepFn: noSleep,
+    });
+
+    expect(result.success).toBe(true);
+    expect(publishes).toBe(3);
+  });
+
+  it('fails fast on non-retryable publish errors', async () => {
+    let publishes = 0;
+    const authError = new Error('ENEEDAUTH');
+    authError.nonRetryable = true;
+    const result = await publishWithRetry({
+      publish: async () => {
+        publishes++;
+        return { success: false, error: authError, output: 'ENEEDAUTH' };
+      },
+      verify: async () => true,
+      sleepFn: noSleep,
+    });
+
+    expect(result.success).toBe(false);
+    expect(publishes).toBe(1);
+    expect(result.error.message).toBe('ENEEDAUTH');
+  });
+
+  it('treats an already-published conflict as a cue to verify', async () => {
+    let publishes = 0;
+    const result = await publishWithRetry({
+      publish: async () => {
+        publishes++;
+        return {
+          success: false,
+          error: new Error('npm error code EPUBLISHCONFLICT'),
+          output: 'npm error code EPUBLISHCONFLICT',
+        };
+      },
+      verify: async () => true,
+      sleepFn: noSleep,
+    });
+
+    expect(result.success).toBe(true);
+    expect(publishes).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #105

## Problem

`scripts/publish-to-npm.mjs` treated "publish succeeded" and "verification succeeded" as one retryable unit. When the publish worked but the single check 2s later missed because npm's registry had not propagated, the retry loop re-ran the whole `changeset publish`, which then failed with "cannot publish over the previously published versions" — turning a successful release into a reported failure.

## Solution

New module `scripts/publish-retry.mjs` splits the two failure domains:

- `waitForVersionOnRegistry()` — bounded polling with exponential backoff (7 attempts, 2s → 30s cap). A thrown E404/network error is treated as a miss and polling continues.
- `publishWithRetry()` — retries `changeset publish` **only** when the publish command itself failed. Once a publish reports success, the flow moves to verification and never re-enters the publish path; an exhausted poll fails the release without republishing.
- `isAlreadyPublishedError()` — `EPUBLISHCONFLICT` / "cannot publish over the previously published versions" is treated as a cue to verify, not to fail.

Verification is still mandatory: a publish that falsely claims success still fails the release.

`publish-to-npm.mjs` now delegates to `publishWithRetry`; `attemptPublish` became `runPublishCommand` (publish only, no verification). Non-retryable auth guidance from #77 is preserved.

## Reproduction / tests

`tests/publish-retry.test.js` encodes the scenario from the issue — a runner whose publish succeeds once and whose verification misses twice:

- one publish, verification eventually succeeds, success ✅ (previously: a second publish attempt and a conflict)
- exhausted verification polling fails without republishing
- publish-command failures still retry
- non-retryable auth errors still fail fast
- backoff sequence is capped at `maxDelay`

All 169 tests pass; `npm run lint`, `format:check` and `check:duplication` are clean.