### PR TITLE
Report lint warnings only on changed lines

### DIFF
--- a/.changeset/lint-warnings-on-changed-lines.md
+++ b/.changeset/lint-warnings-on-changed-lines.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Report ESLint warnings only on lines changed relative to the base branch, so unchanged findings such as `local/no-changelog-comments` stop repeating on every run. Errors are still reported for all files.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-07-20T10:47:17.147Z for PR creation at branch issue-104-fea61a10d5f1 for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/104
 # .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106
 # Updated: 2026-07-20T11:05:28.272Z
+# Updated: 2026-07-20T11:57:21.324Z

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -101,6 +101,17 @@ export default [
     },
   },
   {
+    // Case studies preserve historical wording on purpose, and the rule's own
+    // tests contain fixtures the rule is designed to flag.
+    files: [
+      'docs/case-studies/**/*.{js,mjs,cjs}',
+      'tests/no-changelog-comments.test.js',
+    ],
+    rules: {
+      'local/no-changelog-comments': 'off',
+    },
+  },
+  {
     ignores: [
       'node_modules/**',
       '**/node_modules/**',

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "scripts": {
     "test": "node --test --test-timeout=30000 tests/*.test.js",
-    "lint": "eslint .",
+    "lint": "node scripts/lint.mjs",
+    "lint:all": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/lint-changed-lines.mjs
+++ b/scripts/lint-changed-lines.mjs
@@ -1,0 +1,111 @@
+/**
+ * Helpers for reporting ESLint warnings only on changed lines.
+ *
+ * Errors are always reported, everywhere. Warnings are noise when they come
+ * from untouched code: every run repeats the same findings and hides the new
+ * ones. These helpers map a unified diff to the set of added/modified lines per
+ * file and drop warnings that fall outside that set.
+ */
+
+import path from 'node:path';
+
+const HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
+
+/**
+ * Parse a unified diff into a map of file path -> Set of changed line numbers
+ * (line numbers of the new file revision).
+ *
+ * @param {string} diff unified diff text (`git diff -U0`)
+ * @returns {Map<string, Set<number>>}
+ */
+export function parseChangedLines(diff) {
+  const changed = new Map();
+  let currentFile = null;
+  let lineNumber = 0;
+
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('+++ ')) {
+      const target = line.slice(4).trim();
+      currentFile = target === '/dev/null' ? null : target.replace(/^b\//, '');
+      if (currentFile && !changed.has(currentFile)) {
+        changed.set(currentFile, new Set());
+      }
+      continue;
+    }
+
+    const hunk = HUNK_HEADER.exec(line);
+    if (hunk) {
+      lineNumber = Number(hunk[1]);
+      continue;
+    }
+
+    if (!currentFile) {
+      continue;
+    }
+
+    if (line.startsWith('+')) {
+      changed.get(currentFile).add(lineNumber);
+      lineNumber += 1;
+    } else if (line.startsWith(' ')) {
+      lineNumber += 1;
+    }
+  }
+
+  return changed;
+}
+
+function relativePath(filePath, cwd) {
+  return path.relative(cwd, filePath).split(path.sep).join('/');
+}
+
+/**
+ * Keep every error, and keep warnings only when they touch a changed line of a
+ * changed file.
+ *
+ * @param {Array<object>} results ESLint result objects
+ * @param {Map<string, Set<number>|true>} changedLines from {@link parseChangedLines};
+ *   a `true` value means the whole file is new
+
+ * @param {string} cwd directory the result paths are relative to
+ * @returns {Array<object>} filtered ESLint results
+ */
+export function filterWarningsToChangedLines(results, changedLines, cwd) {
+  return results.map((result) => {
+    const fileChanges = changedLines.get(relativePath(result.filePath, cwd));
+
+    const messages = result.messages.filter((message) => {
+      if (message.severity !== 1) {
+        return true;
+      }
+
+      if (!fileChanges) {
+        return false;
+      }
+
+      // `true` marks a wholly new file: every line counts as changed.
+      if (fileChanges === true) {
+        return true;
+      }
+
+      const start = message.line ?? 0;
+      const end = message.endLine ?? start;
+
+      for (let line = start; line <= end; line += 1) {
+        if (fileChanges.has(line)) {
+          return true;
+        }
+      }
+
+      return false;
+    });
+
+    return {
+      ...result,
+      messages,
+      warningCount: messages.filter((message) => message.severity === 1).length,
+      fixableWarningCount: messages.filter(
+        (message) => message.severity === 1 && message.fix
+      ).length,
+    };
+  });
+}

--- a/scripts/lint.mjs
+++ b/scripts/lint.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * Lint entry point used by `npm run lint`.
+ *
+ * All files are linted for errors. Warnings are annotated only on lines that
+ * the current branch changes relative to its base, keeping each run focused on
+ * actionable findings. Set LINT_ALL_WARNINGS=1 to report every warning.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { ESLint } from 'eslint';
+import {
+  parseChangedLines,
+  filterWarningsToChangedLines,
+} from './lint-changed-lines.mjs';
+
+function git(args) {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+function resolveBaseRef() {
+  const baseRef = process.env.LINT_BASE_REF || process.env.GITHUB_BASE_REF;
+  const candidates = baseRef
+    ? [baseRef, `origin/${baseRef}`]
+    : ['origin/main', 'main', 'origin/master', 'master'];
+
+  for (const candidate of candidates) {
+    try {
+      git(['rev-parse', '--verify', '--quiet', `${candidate}^{commit}`]);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function collectChangedLines() {
+  const base = resolveBaseRef();
+
+  if (!base) {
+    return null;
+  }
+
+  try {
+    const mergeBase = git(['merge-base', 'HEAD', base]).trim();
+    const committed = git(['diff', '-U0', mergeBase, '--']);
+    const working = git(['diff', '-U0', 'HEAD', '--']);
+    const untracked = git(['ls-files', '--others', '--exclude-standard'])
+      .split('\n')
+      .filter(Boolean);
+
+    const changed = parseChangedLines(`${committed}\n${working}`);
+
+    for (const file of untracked) {
+      changed.set(file, true);
+    }
+
+    return changed;
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const eslint = new ESLint();
+  const results = await eslint.lintFiles(['.']);
+  const changedLines =
+    process.env.LINT_ALL_WARNINGS === '1' ? null : collectChangedLines();
+
+  const reported = changedLines
+    ? filterWarningsToChangedLines(results, changedLines, process.cwd())
+    : results;
+
+  const formatter = await eslint.loadFormatter('stylish');
+  const output = await formatter.format(reported);
+
+  if (output) {
+    console.log(output);
+  }
+
+  const errorCount = reported.reduce(
+    (total, result) => total + result.errorCount,
+    0
+  );
+
+  const hiddenWarnings =
+    results.reduce((total, result) => total + result.warningCount, 0) -
+    reported.reduce((total, result) => total + result.warningCount, 0);
+
+  if (hiddenWarnings > 0) {
+    console.log(
+      `${hiddenWarnings} warning(s) on unchanged lines were not reported. Run LINT_ALL_WARNINGS=1 npm run lint to see them.`
+    );
+  }
+
+  process.exit(errorCount > 0 ? 1 : 0);
+}
+
+await main();

--- a/tests/lint-changed-lines.test.js
+++ b/tests/lint-changed-lines.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'test-anywhere';
+import {
+  parseChangedLines,
+  filterWarningsToChangedLines,
+} from '../scripts/lint-changed-lines.mjs';
+
+const DIFF = [
+  'diff --git a/scripts/example.mjs b/scripts/example.mjs',
+  '--- a/scripts/example.mjs',
+  '+++ b/scripts/example.mjs',
+  '@@ -10,0 +11,2 @@',
+  '+// this line is new',
+  '+const value = 1;',
+  '',
+].join('\n');
+
+function warning(line) {
+  return {
+    severity: 1,
+    line,
+    ruleId: 'local/no-changelog-comments',
+    message: 'history',
+  };
+}
+
+describe('parseChangedLines', () => {
+  it('collects added line numbers per file', () => {
+    const changed = parseChangedLines(DIFF);
+
+    expect(Array.from(changed.get('scripts/example.mjs'))).toEqual([11, 12]);
+  });
+});
+
+describe('filterWarningsToChangedLines', () => {
+  const cwd = '/repo';
+  const changed = parseChangedLines(DIFF);
+
+  it('keeps warnings on changed lines', () => {
+    const [result] = filterWarningsToChangedLines(
+      [
+        {
+          filePath: '/repo/scripts/example.mjs',
+          messages: [warning(11)],
+          errorCount: 0,
+          warningCount: 1,
+        },
+      ],
+      changed,
+      cwd
+    );
+
+    expect(result.messages.length).toBe(1);
+    expect(result.warningCount).toBe(1);
+  });
+
+  it('drops warnings on unchanged lines of a changed file', () => {
+    const [result] = filterWarningsToChangedLines(
+      [
+        {
+          filePath: '/repo/scripts/example.mjs',
+          messages: [warning(3)],
+          errorCount: 0,
+          warningCount: 1,
+        },
+      ],
+      changed,
+      cwd
+    );
+
+    expect(result.messages.length).toBe(0);
+    expect(result.warningCount).toBe(0);
+  });
+
+  it('drops warnings from files that were not touched at all', () => {
+    const [result] = filterWarningsToChangedLines(
+      [
+        {
+          filePath: '/repo/scripts/other.mjs',
+          messages: [warning(1)],
+          errorCount: 0,
+          warningCount: 1,
+        },
+      ],
+      changed,
+      cwd
+    );
+
+    expect(result.messages.length).toBe(0);
+  });
+
+  it('keeps every warning of a wholly new file', () => {
+    const newFileChanges = new Map([['scripts/new.mjs', true]]);
+    const [result] = filterWarningsToChangedLines(
+      [
+        {
+          filePath: '/repo/scripts/new.mjs',
+          messages: [warning(42)],
+          errorCount: 0,
+          warningCount: 1,
+        },
+      ],
+      newFileChanges,
+      cwd
+    );
+
+    expect(result.messages.length).toBe(1);
+  });
+
+  it('always keeps errors regardless of the diff', () => {
+    const [result] = filterWarningsToChangedLines(
+      [
+        {
+          filePath: '/repo/scripts/other.mjs',
+          messages: [{ severity: 2, line: 5, ruleId: 'no-var' }],
+          errorCount: 1,
+          warningCount: 0,
+        },
+      ],
+      changed,
+      cwd
+    );
+
+    expect(result.messages.length).toBe(1);
+    expect(result.errorCount).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #103

## Problem
Every Release run re-emitted the same `local/no-changelog-comments` warnings from files already on the default branch (33 in run 29434577797), hiding new actionable findings.

## Solution
- `scripts/lint-changed-lines.mjs`: parses `git diff -U0` into per-file changed line sets and filters ESLint results — errors always kept, warnings kept only when they land on a changed line (whole file for new/untracked files).
- `scripts/lint.mjs`: new `npm run lint` entry point that lints everything, reports filtered results, and prints how many warnings were suppressed. `LINT_ALL_WARNINGS=1` (or `npm run lint:all`) restores the full output.
- `eslint.config.js`: disables the rule for `docs/case-studies/**` fixtures and for `tests/no-changelog-comments.test.js`, which intentionally contain historical wording.

## Verification
`tests/lint-changed-lines.test.js` proves an unchanged baseline warning is not re-annotated while a warning on a newly changed line is, and that errors survive filtering.

```
$ npm run lint          # 0 problems (21 warnings on unchanged lines suppressed)
$ LINT_ALL_WARNINGS=1 npm run lint   # 21 warnings
$ node --test tests/lint-changed-lines.test.js   # 6/6 pass
```