### PR TITLE
fix(ci): honor excluded paths for all events

### DIFF
--- a/.changeset/filter-excluded-ci-paths.md
+++ b/.changeset/filter-excluded-ci-paths.md
@@ -1,0 +1,6 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Keep excluded-directory changes from activating change-gated CI jobs on pull
+requests and direct pushes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,8 @@ jobs:
     timeout-minutes: 5
     if: github.event_name != 'workflow_dispatch'
     outputs:
-      mjs-changed: ${{ steps.changes.outputs.mjs-changed }}
       js-changed: ${{ steps.changes.outputs.js-changed }}
-      package-changed: ${{ steps.changes.outputs.package-changed }}
       docs-changed: ${{ steps.changes.outputs.docs-changed }}
-      workflow-changed: ${{ steps.changes.outputs.workflow-changed }}
       any-code-changed: ${{ steps.changes.outputs.any-code-changed }}
     steps:
       - uses: actions/checkout@v6
@@ -89,8 +86,6 @@ jobs:
     timeout-minutes: 5
     needs: [detect-changes]
     if: |
-      github.event_name == 'push' ||
-      needs.detect-changes.outputs.mjs-changed == 'true' ||
       needs.detect-changes.outputs.js-changed == 'true'
     steps:
       - uses: actions/checkout@v6
@@ -106,11 +101,8 @@ jobs:
     timeout-minutes: 5
     needs: [detect-changes]
     if: |
-      github.event_name == 'push' ||
-      needs.detect-changes.outputs.mjs-changed == 'true' ||
-      needs.detect-changes.outputs.js-changed == 'true' ||
       needs.detect-changes.outputs.docs-changed == 'true' ||
-      needs.detect-changes.outputs.workflow-changed == 'true'
+      needs.detect-changes.outputs.any-code-changed == 'true'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -200,12 +192,8 @@ jobs:
     timeout-minutes: 10
     needs: [detect-changes]
     if: |
-      github.event_name == 'push' ||
-      needs.detect-changes.outputs.mjs-changed == 'true' ||
-      needs.detect-changes.outputs.js-changed == 'true' ||
       needs.detect-changes.outputs.docs-changed == 'true' ||
-      needs.detect-changes.outputs.package-changed == 'true' ||
-      needs.detect-changes.outputs.workflow-changed == 'true'
+      needs.detect-changes.outputs.any-code-changed == 'true'
     steps:
       - uses: actions/checkout@v6
         with:
@@ -258,20 +246,13 @@ jobs:
         check-file-line-limits,
       ]
     # Use !cancelled() instead of always() so cancellation propagates correctly (hive-mind issue #1278)
-    # Run on pushes, or PRs with code/package/workflow changes that can affect
-    # test results. Skipped fast checks still count as non-failures only after
-    # this positive change-detector gate passes.
+    # Run for relevant code/package/workflow changes that can affect test
+    # results. Skipped fast checks count as non-failures only after this
+    # positive change-detector gate passes.
     if: |
       !cancelled() &&
-      (
-        github.event_name == 'push' ||
-        needs.detect-changes.outputs.any-code-changed == 'true' ||
-        needs.detect-changes.outputs.mjs-changed == 'true' ||
-        needs.detect-changes.outputs.js-changed == 'true' ||
-        needs.detect-changes.outputs.package-changed == 'true' ||
-        needs.detect-changes.outputs.workflow-changed == 'true'
-      ) &&
-      (github.event_name == 'push' || needs.changeset-check.result == 'success' || needs.changeset-check.result == 'skipped') &&
+      needs.detect-changes.outputs.any-code-changed == 'true' &&
+      (needs.changeset-check.result == 'success' || needs.changeset-check.result == 'skipped') &&
       (needs.test-compilation.result == 'success' || needs.test-compilation.result == 'skipped') &&
       (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
       (needs.check-file-line-limits.result == 'success' || needs.check-file-line-limits.result == 'skipped')
@@ -383,7 +364,6 @@ jobs:
     timeout-minutes: 5
     needs: [detect-changes]
     if: |
-      github.event_name == 'push' ||
       needs.detect-changes.outputs.docs-changed == 'true'
     steps:
       - uses: actions/checkout@v6

--- a/.gitkeep
+++ b/.gitkeep
@@ -2,4 +2,3 @@
 # .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106
 # Updated: 2026-07-20T11:05:28.272Z
 # Updated: 2026-07-20T11:57:21.324Z
-# Updated: 2026-07-27T04:07:04.321Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -2,3 +2,4 @@
 # .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106
 # Updated: 2026-07-20T11:05:28.272Z
 # Updated: 2026-07-20T11:57:21.324Z
+# Updated: 2026-07-27T04:07:04.321Z

--- a/scripts/detect-code-changes.mjs
+++ b/scripts/detect-code-changes.mjs
@@ -13,19 +13,30 @@
 // This lets PR synchronize runs skip slow checks when the latest PR head
 // commit is docs-only, while real merge pushes still evaluate the whole merge.
 //
-// Excluded from code changes (don't require changesets):
-// - Markdown files in any folder
+// Ignored for every change-gating output:
 // - .changeset/ folder (changeset metadata)
-// - docs/ folder (documentation)
+// - docs/case-studies/ folder (research documents)
+// - dev/log/ folder (development logs)
 // - experiments/ folder (experimental scripts)
 // - examples/ folder (example scripts)
 //
+// Additionally excluded from code changes (don't require changesets):
+// - Markdown files in any folder
+// - docs/ folder (documentation)
+//
 // Outputs (written to GITHUB_OUTPUT):
-//   mjs-changed, js-changed, package-changed, docs-changed,
-//   workflow-changed, any-code-changed
+//   js-changed, docs-changed, any-code-changed
 
 import { execFileSync } from 'child_process';
 import { appendFileSync } from 'fs';
+
+const ignoredPathPrefixes = [
+  '.changeset/',
+  'dev/log/',
+  'docs/case-studies/',
+  'examples/',
+  'experiments/',
+];
 
 function execGit(args) {
   try {
@@ -108,15 +119,7 @@ function isExcludedFromCodeChanges(filePath) {
     return true;
   }
 
-  const excludedFolders = ['.changeset/', 'docs/', 'experiments/', 'examples/'];
-
-  for (const folder of excludedFolders) {
-    if (filePath.startsWith(folder)) {
-      return true;
-    }
-  }
-
-  return false;
+  return filePath.startsWith('docs/');
 }
 
 function detectChanges() {
@@ -132,26 +135,19 @@ function detectChanges() {
   }
   console.log('');
 
-  const mjsChanged = changedFiles.some((file) => file.endsWith('.mjs'));
-  setOutput('mjs-changed', mjsChanged ? 'true' : 'false');
+  const relevantChangedFiles = changedFiles.filter(
+    (file) => !ignoredPathPrefixes.some((prefix) => file.startsWith(prefix))
+  );
 
-  const jsChanged = changedFiles.some(
-    (file) => file.endsWith('.js') || file.endsWith('.cjs')
+  const jsChanged = relevantChangedFiles.some((file) =>
+    /\.(mjs|cjs|js)$/.test(file)
   );
   setOutput('js-changed', jsChanged ? 'true' : 'false');
 
-  const packageChanged = changedFiles.some((file) => file === 'package.json');
-  setOutput('package-changed', packageChanged ? 'true' : 'false');
-
-  const docsChanged = changedFiles.some((file) => file.endsWith('.md'));
+  const docsChanged = relevantChangedFiles.some((file) => file.endsWith('.md'));
   setOutput('docs-changed', docsChanged ? 'true' : 'false');
 
-  const workflowChanged = changedFiles.some((file) =>
-    file.startsWith('.github/workflows/')
-  );
-  setOutput('workflow-changed', workflowChanged ? 'true' : 'false');
-
-  const codeChangedFiles = changedFiles.filter(
+  const codeChangedFiles = relevantChangedFiles.filter(
     (file) => !isExcludedFromCodeChanges(file)
   );
 

--- a/tests/detect-code-changes.test.js
+++ b/tests/detect-code-changes.test.js
@@ -66,7 +66,7 @@ function createMergeCommitFixture() {
   return root;
 }
 
-function createExcludedChangeFixture(filePath, eventName) {
+function createChangeFixture(filePath, eventName) {
   const root = mkdtempSync(path.join(tmpdir(), 'detect-code-changes-'));
 
   runGit(root, ['init', '-b', 'main']);
@@ -149,7 +149,7 @@ describe('detect-code-changes CLI', () => {
         'docs/case-studies/issue-113/repro.md',
       ]) {
         it(`ignores ${filePath} changes on ${eventName}`, () => {
-          const root = createExcludedChangeFixture(filePath, eventName);
+          const root = createChangeFixture(filePath, eventName);
 
           try {
             const { outputs, result } = runDetectCodeChanges(root, eventName);
@@ -166,6 +166,24 @@ describe('detect-code-changes CLI', () => {
           }
         });
       }
+    }
+
+    for (const [filePath, expectedOutput] of [
+      ['src/relevant.mjs', 'js-changed=true\n'],
+      ['docs/relevant.md', 'docs-changed=true\n'],
+    ]) {
+      it(`keeps detecting non-ignored ${filePath} changes`, () => {
+        const root = createChangeFixture(filePath, 'push');
+
+        try {
+          const { outputs, result } = runDetectCodeChanges(root, 'push');
+
+          expect(result.status).toBe(0);
+          expect(outputs).toContain(expectedOutput);
+        } finally {
+          rmSync(root, { force: true, recursive: true });
+        }
+      });
     }
   }
 });

--- a/tests/detect-code-changes.test.js
+++ b/tests/detect-code-changes.test.js
@@ -66,6 +66,32 @@ function createMergeCommitFixture() {
   return root;
 }
 
+function createExcludedChangeFixture(filePath, eventName) {
+  const root = mkdtempSync(path.join(tmpdir(), 'detect-code-changes-'));
+
+  runGit(root, ['init', '-b', 'main']);
+  runGit(root, ['config', 'user.email', 'ci@example.com']);
+  runGit(root, ['config', 'user.name', 'CI Test']);
+
+  writeFileSync(path.join(root, 'README.md'), '# Fixture\n');
+  commit(root, 'Initial commit');
+
+  if (eventName === 'pull_request') {
+    runGit(root, ['checkout', '-b', 'feature']);
+  }
+
+  mkdirSync(path.dirname(path.join(root, filePath)), { recursive: true });
+  writeFileSync(path.join(root, filePath), 'export const ignored = true;\n');
+  commit(root, 'Add excluded file');
+
+  if (eventName === 'pull_request') {
+    runGit(root, ['checkout', 'main']);
+    runGit(root, ['merge', '--no-ff', 'feature', '-m', 'Synthetic PR merge']);
+  }
+
+  return root;
+}
+
 function runDetectCodeChanges(root, eventName) {
   const outputFile = path.join(root, 'github-output.txt');
   const result = spawnSync(process.execPath, [scriptPath], {
@@ -93,7 +119,7 @@ describe('detect-code-changes CLI', () => {
         const { outputs, result } = runDetectCodeChanges(root, 'push');
 
         expect(result.status).toBe(0);
-        expect(outputs).toContain('mjs-changed=true\n');
+        expect(outputs).toContain('js-changed=true\n');
         expect(outputs).toContain('docs-changed=true\n');
         expect(outputs).toContain('any-code-changed=true\n');
       } finally {
@@ -108,12 +134,38 @@ describe('detect-code-changes CLI', () => {
         const { outputs, result } = runDetectCodeChanges(root, 'pull_request');
 
         expect(result.status).toBe(0);
-        expect(outputs).toContain('mjs-changed=false\n');
+        expect(outputs).toContain('js-changed=false\n');
         expect(outputs).toContain('docs-changed=true\n');
         expect(outputs).toContain('any-code-changed=false\n');
       } finally {
         rmSync(root, { force: true, recursive: true });
       }
     });
+
+    for (const eventName of ['pull_request', 'push']) {
+      for (const filePath of [
+        'experiments/repro.mjs',
+        'dev/log/repro.js',
+        'docs/case-studies/issue-113/repro.md',
+      ]) {
+        it(`ignores ${filePath} changes on ${eventName}`, () => {
+          const root = createExcludedChangeFixture(filePath, eventName);
+
+          try {
+            const { outputs, result } = runDetectCodeChanges(root, eventName);
+
+            expect(result.status).toBe(0);
+            expect(outputs).toContain('js-changed=false\n');
+            expect(outputs).toContain('docs-changed=false\n');
+            expect(outputs).toContain('any-code-changed=false\n');
+            expect(outputs).not.toContain('mjs-changed=');
+            expect(outputs).not.toContain('package-changed=');
+            expect(outputs).not.toContain('workflow-changed=');
+          } finally {
+            rmSync(root, { force: true, recursive: true });
+          }
+        });
+      }
+    }
   }
 });

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -88,10 +88,8 @@ function createTestJobContext({
       'detect-changes': {
         outputs: {
           'any-code-changed': 'false',
-          'mjs-changed': 'false',
           'js-changed': 'false',
-          'package-changed': 'false',
-          'workflow-changed': 'false',
+          'docs-changed': 'false',
           ...outputs,
         },
       },
@@ -272,13 +270,29 @@ describe('release workflow change gates', () => {
     const workflowPullRequest = createTestJobContext({
       outputs: {
         'any-code-changed': 'true',
-        'workflow-changed': 'true',
       },
       result: 'success',
     });
 
     expect(evaluateWorkflowIf(testCondition, workflowPullRequest)).toBe(true);
   });
+
+  for (const jobName of [
+    'test-compilation',
+    'check-file-line-limits',
+    'lint',
+    'test',
+    'validate-docs',
+  ]) {
+    it(`skips ${jobName} for excluded-only pushes`, () => {
+      const workflow = readWorkflow('.github/workflows/release.yml');
+      const job = getJobBlock(workflow, jobName);
+      const condition = getMultilineIfExpression(job);
+      const excludedOnlyPush = createTestJobContext({ eventName: 'push' });
+
+      expect(evaluateWorkflowIf(condition, excludedOnlyPush)).toBe(false);
+    });
+  }
 });
 
 describe('npm publish token bootstrap', () => {


### PR DESCRIPTION
Fixes #113

## Summary

- filter ignored path prefixes before computing every change-gating output
- remove unconditional push bypasses from change-gated jobs
- consolidate JavaScript detection and remove redundant detector outputs
- cover pull request and push events for `experiments/`, `dev/log/`, and `docs/case-studies/`

## Reproduction

Before this change, a direct push containing only an excluded file still ran lint, tests, and other gated jobs because each condition included an unconditional push alternative. On pull requests, excluded `.mjs`, `.js`, and `.md` files could independently set extension outputs before the exclusion policy was applied.

The new regression fixtures create excluded-only commits for both pull request synthetic merges and direct pushes. They verify that every detector output remains false and that all change-gated workflow jobs evaluate to skipped.

## Verification

- `node --test --test-timeout=30000 tests/detect-code-changes.test.js tests/workflow-reliability.test.js`
- `npm test`
- `npm run check`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`
