### PR TITLE
fix(ci): reject unsupported workflow concurrency keys

### DIFF
--- a/.changeset/valid-concurrency-keys.md
+++ b/.changeset/valid-concurrency-keys.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Reject unsupported keys in generated workflow concurrency blocks.

--- a/.gitkeep
+++ b/.gitkeep
@@ -2,4 +2,3 @@
 # .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106
 # Updated: 2026-07-20T11:05:28.272Z
 # Updated: 2026-07-20T11:57:21.324Z
-# Updated: 2026-08-01T16:29:57.699Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -2,3 +2,4 @@
 # .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106
 # Updated: 2026-07-20T11:05:28.272Z
 # Updated: 2026-07-20T11:57:21.324Z
+# Updated: 2026-08-01T16:29:57.699Z

--- a/docs/BEST-PRACTICES.md
+++ b/docs/BEST-PRACTICES.md
@@ -110,7 +110,10 @@ Do not apply cancellable concurrency at workflow level when a workflow contains
 write jobs: cancelling the workflow would also terminate a publisher that has
 already started. Likewise, do not use one shared group for every read-only job,
 because unrelated checks would cancel each other instead of running in
-parallel.
+parallel. GitHub Actions concurrency blocks support only `group` and
+`cancel-in-progress`; options such as `queue` are invalid. With
+`cancel-in-progress: false`, GitHub preserves the running job and manages one
+pending job for the group.
 
 See [DETAILED-COMPARISON.md](./case-studies/issue-25/DETAILED-COMPARISON.md) for the full analysis of best practices from both repositories.
 

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -1,8 +1,56 @@
 import { describe, it, expect } from 'test-anywhere';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
+
+const WORKFLOW_DIRECTORY = '.github/workflows';
+const SUPPORTED_CONCURRENCY_KEYS = new Set(['group', 'cancel-in-progress']);
 
 function readWorkflow(filePath) {
   return readFileSync(filePath, 'utf8').replaceAll('\r\n', '\n');
+}
+
+function listWorkflowPaths() {
+  return readdirSync(WORKFLOW_DIRECTORY)
+    .filter((fileName) => /\.ya?ml$/.test(fileName))
+    .map((fileName) => `${WORKFLOW_DIRECTORY}/${fileName}`);
+}
+
+function getUnsupportedConcurrencyKeys(workflow) {
+  const lines = workflow.split('\n');
+  const unsupportedKeys = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const concurrency = lines[index].match(/^(\s*)concurrency:\s*$/);
+
+    if (!concurrency) {
+      continue;
+    }
+
+    const keyIndentation = concurrency[1].length + 2;
+
+    for (const line of lines.slice(index + 1)) {
+      if (line.trim() === '' || line.trimStart().startsWith('#')) {
+        continue;
+      }
+
+      const indentation = line.match(/^\s*/)[0].length;
+
+      if (indentation <= concurrency[1].length) {
+        break;
+      }
+
+      if (indentation !== keyIndentation) {
+        continue;
+      }
+
+      const key = line.trimStart().match(/^([a-zA-Z0-9_-]+):/)?.[1];
+
+      if (key && !SUPPORTED_CONCURRENCY_KEYS.has(key)) {
+        unsupportedKeys.push(key);
+      }
+    }
+  }
+
+  return unsupportedKeys;
 }
 
 function getJobBlock(workflow, jobName) {
@@ -112,6 +160,34 @@ function createTestJobContext({
 }
 
 describe('workflow concurrency policy', () => {
+  it('detects unsupported keys in a concurrency block', () => {
+    const invalidWorkflow = [
+      'jobs:',
+      '  publish:',
+      '    concurrency:',
+      '      group: main-writer',
+      '      cancel-in-progress: false',
+      '      queue: max',
+      '    steps: []',
+    ].join('\n');
+
+    expect(getUnsupportedConcurrencyKeys(invalidWorkflow)).toEqual(['queue']);
+  });
+
+  it('uses only keys supported by GitHub Actions', () => {
+    const violations = [];
+
+    for (const workflowPath of listWorkflowPaths()) {
+      const workflow = readWorkflow(workflowPath);
+
+      for (const key of getUnsupportedConcurrencyKeys(workflow)) {
+        violations.push(`${workflowPath}: ${key}`);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
   it('uses job-level concurrency so stale checks cannot cancel active writers', () => {
     const workflowPaths = [
       '.github/workflows/example-app.yml',


### PR DESCRIPTION
## What

- Scan every checked-in workflow concurrency block and fail tests when a key other than `group` or `cancel-in-progress` is present.
- Add a minimal `queue: max` regression fixture proving the policy detects the reported invalid key.
- Document GitHub Actions' supported concurrency keys and pending-job behavior.
- Add a patch changeset for the generated-workflow safeguard.

## Why

GitHub Actions concurrency blocks support only `group` and `cancel-in-progress`; `queue: max` causes actionlint v1.7.12 to report an unexpected key. The invalid key was not present in current `main` or the prepared branch when this fix began, so this change closes the regression gap that allowed an exact expected block to pass even if an unsupported sibling key was added later. Existing `cancel-in-progress: false` writer behavior is preserved.

## Reproduction

The focused regression fixture contains:

```yaml
concurrency:
  group: main-writer
  cancel-in-progress: false
  queue: max
```

The new policy scanner reports `queue` as unsupported. It also scans every `.yml` and `.yaml` file in `.github/workflows`.

## Verification

- `actionlint` v1.7.12 over `.github/workflows/*.yml`
- `npm test` — 198 passing
- `bun test --timeout 30000` — 198 passing
- `deno test --allow-read` — 167 passing
- `npm run check`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`

Fixes #117
