### PR TITLE
fix(ci): gate manual releases on quality checks

### DIFF
--- a/.changeset/manual-release-quality-gates.md
+++ b/.changeset/manual-release-quality-gates.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Require successful lint and test quality gates before manual releases can publish.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,8 +202,12 @@ jobs:
       cancel-in-progress: true
     needs: [detect-changes]
     if: |
-      needs.detect-changes.outputs.docs-changed == 'true' ||
-      needs.detect-changes.outputs.any-code-changed == 'true'
+      !cancelled() &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        needs.detect-changes.outputs.docs-changed == 'true' ||
+        needs.detect-changes.outputs.any-code-changed == 'true'
+      )
     steps:
       - uses: actions/checkout@v6
         with:
@@ -259,12 +263,18 @@ jobs:
         check-file-line-limits,
       ]
     # Use !cancelled() instead of always() so cancellation propagates correctly (hive-mind issue #1278)
-    # Run for relevant code/package/workflow changes that can affect test
-    # results. Skipped fast checks count as non-failures only after this
-    # positive change-detector gate passes.
+    # Run for relevant code/package/workflow changes, or for an instant manual
+    # release. Skipped fast checks count as non-failures only after one of
+    # those positive gates passes.
     if: |
       !cancelled() &&
-      needs.detect-changes.outputs.any-code-changed == 'true' &&
+      (
+        needs.detect-changes.outputs.any-code-changed == 'true' ||
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.event.inputs.release_mode == 'instant'
+        )
+      ) &&
       (needs.changeset-check.result == 'success' || needs.changeset-check.result == 'skipped') &&
       (needs.test-compilation.result == 'success' || needs.test-compilation.result == 'skipped') &&
       (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
@@ -526,7 +536,14 @@ jobs:
   # only allows one workflow file to be registered as a trusted publisher
   instant-release:
     name: Instant Release
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'instant'
+    # Publishing must wait for both quality gates and require explicit success.
+    needs: [lint, test]
+    if: |
+      !cancelled() &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.release_mode == 'instant' &&
+      needs.lint.result == 'success' &&
+      needs.test.result == 'success'
     runs-on: ubuntu-latest
     # Same publish envelope as the automated release path.
     timeout-minutes: 30
@@ -645,7 +662,13 @@ jobs:
   # Manual Changeset PR - creates a pull request with the changeset for review
   changeset-pr:
     name: Create Changeset PR
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changeset-pr'
+    # PR creation does not publish, but it must still pass the fast lint gate.
+    needs: [lint]
+    if: |
+      !cancelled() &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.release_mode == 'changeset-pr' &&
+      needs.lint.result == 'success'
     runs-on: ubuntu-latest
     # PR creation only: install, create a changeset, format, and open a PR.
     timeout-minutes: 10

--- a/.gitkeep
+++ b/.gitkeep
@@ -2,4 +2,3 @@
 # .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106
 # Updated: 2026-07-20T11:05:28.272Z
 # Updated: 2026-07-20T11:57:21.324Z
-# Updated: 2026-08-02T20:22:39.368Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -2,3 +2,4 @@
 # .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106
 # Updated: 2026-07-20T11:05:28.272Z
 # Updated: 2026-07-20T11:57:21.324Z
+# Updated: 2026-08-02T20:22:39.368Z

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -94,6 +94,10 @@ function evaluateWorkflowIf(expression, context) {
   const javaScriptExpression = expression
     .replaceAll('!cancelled()', '!context.cancelled')
     .replaceAll('github.event_name', 'context.github.event_name')
+    .replaceAll(
+      'github.event.inputs.release_mode',
+      'context.github.event.inputs.release_mode'
+    )
     .replace(
       /needs\.([a-zA-Z0-9_-]+)\.outputs\.([a-zA-Z0-9_-]+)/g,
       'context.needs["$1"].outputs["$2"]'
@@ -134,6 +138,7 @@ function expectCancellableCheckConcurrency(
 
 function createTestJobContext({
   eventName = 'pull_request',
+  releaseMode,
   outputs = {},
   result = 'skipped',
 } = {}) {
@@ -141,6 +146,11 @@ function createTestJobContext({
     cancelled: false,
     github: {
       event_name: eventName,
+      event: {
+        inputs: {
+          release_mode: releaseMode,
+        },
+      },
     },
     needs: {
       'detect-changes': {
@@ -426,6 +436,112 @@ describe('release workflow change gates', () => {
       const excludedOnlyPush = createTestJobContext({ eventName: 'push' });
 
       expect(evaluateWorkflowIf(condition, excludedOnlyPush)).toBe(false);
+    });
+  }
+});
+
+describe('manual release quality gates', () => {
+  function getManualReleaseContext({
+    releaseMode,
+    lintResult = 'success',
+    testResult = 'success',
+    cancelled = false,
+  }) {
+    const context = createTestJobContext({
+      eventName: 'workflow_dispatch',
+      releaseMode,
+      result: 'skipped',
+    });
+
+    context.cancelled = cancelled;
+    context.needs.lint.result = lintResult;
+    context.needs.test = { result: testResult };
+    return context;
+  }
+
+  it('runs lint and tests before an instant manual release', () => {
+    const workflow = readWorkflow('.github/workflows/release.yml');
+    const lintJob = getJobBlock(workflow, 'lint');
+    const testJob = getJobBlock(workflow, 'test');
+    const instantReleaseJob = getJobBlock(workflow, 'instant-release');
+    const context = getManualReleaseContext({ releaseMode: 'instant' });
+
+    expect(evaluateWorkflowIf(getMultilineIfExpression(lintJob), context)).toBe(
+      true
+    );
+    expect(evaluateWorkflowIf(getMultilineIfExpression(testJob), context)).toBe(
+      true
+    );
+    expect(instantReleaseJob).toContain('    needs: [lint, test]');
+    expect(
+      evaluateWorkflowIf(getMultilineIfExpression(instantReleaseJob), context)
+    ).toBe(true);
+  });
+
+  it('blocks an instant manual release after either quality gate fails', () => {
+    const workflow = readWorkflow('.github/workflows/release.yml');
+    const condition = getMultilineIfExpression(
+      getJobBlock(workflow, 'instant-release')
+    );
+
+    expect(
+      evaluateWorkflowIf(
+        condition,
+        getManualReleaseContext({
+          releaseMode: 'instant',
+          lintResult: 'failure',
+        })
+      )
+    ).toBe(false);
+    expect(
+      evaluateWorkflowIf(
+        condition,
+        getManualReleaseContext({
+          releaseMode: 'instant',
+          testResult: 'failure',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('waits for successful lint before creating a manual changeset PR', () => {
+    const workflow = readWorkflow('.github/workflows/release.yml');
+    const changesetPrJob = getJobBlock(workflow, 'changeset-pr');
+    const condition = getMultilineIfExpression(changesetPrJob);
+
+    expect(changesetPrJob).toContain('    needs: [lint]');
+    expect(
+      evaluateWorkflowIf(
+        condition,
+        getManualReleaseContext({ releaseMode: 'changeset-pr' })
+      )
+    ).toBe(true);
+    expect(
+      evaluateWorkflowIf(
+        condition,
+        getManualReleaseContext({
+          releaseMode: 'changeset-pr',
+          lintResult: 'failure',
+        })
+      )
+    ).toBe(false);
+  });
+
+  for (const jobName of ['instant-release', 'changeset-pr']) {
+    it(`does not run ${jobName} after cancellation`, () => {
+      const workflow = readWorkflow('.github/workflows/release.yml');
+      const condition = getMultilineIfExpression(
+        getJobBlock(workflow, jobName)
+      );
+      const releaseMode =
+        jobName === 'instant-release' ? 'instant' : 'changeset-pr';
+
+      expect(
+        evaluateWorkflowIf(
+          condition,
+          getManualReleaseContext({ releaseMode, cancelled: true })
+        )
+      ).toBe(false);
     });
   }
 });


### PR DESCRIPTION
Fixes #119

## Problem

The manual `instant-release` and `changeset-pr` jobs had no dependencies, so they could begin writing to `main` before validation finished. In particular, an instant release could publish a broken package even when lint or tests failed later in the same workflow run.

There was a second dependency-path concern: `detect-changes` is skipped for `workflow_dispatch`, so simply adding `needs: [lint, test]` would leave the manual jobs permanently skipped unless the quality-gate conditions explicitly survive that skipped dependency.

## Solution

- Run `lint` for manual dispatches while preserving cancellation propagation.
- Run the test matrix for `instant` manual dispatches.
- Make `instant-release` depend on `lint` and `test`, and require both results to be `success`.
- Make `changeset-pr` depend on the faster `lint` gate and require a successful result.
- Keep `!cancelled()` in each condition so skipped transitive dependencies remain evaluable without allowing cancelled runs to write.
- Add a patch changeset.

## Reproduction and regression coverage

Before the workflow change, the new `manual release quality gates` tests fail because the writer jobs have no `needs`, lint/tests do not run on manual dispatch, and cancellation/result checks are absent.

The regression tests now evaluate the workflow conditions and verify that:

- successful lint and tests allow an instant release;
- either lint or test failure blocks publishing;
- changeset PR creation waits for successful lint;
- cancellation blocks both manual writer jobs.

## Testing

- `npm test` — 203 passed
- `bun test --timeout 30000` — 203 passed
- `deno test --allow-read` — 172 passed
- `npm run check` — lint, Prettier, and duplication checks passed
- `bash scripts/check-mjs-syntax.sh` — passed
- `bash scripts/check-file-line-limits.sh` — passed
- `node scripts/validate-changeset.mjs` with PR refs — passed
- Ruby YAML parser validation for `.github/workflows/release.yml` — passed
