### PR TITLE
ci: add CodeQL and dependency review

### DIFF
--- a/.changeset/security-scanning.md
+++ b/.changeset/security-scanning.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Add CodeQL analysis for JavaScript and GitHub Actions plus high-severity dependency review for pull requests.

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,71 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+# Least-privilege default; jobs escalate individually when needed.
+permissions:
+  contents: read
+
+# Provide Git config to actions/checkout itself; checkout runs git init before
+# any workflow step can configure Git.
+env:
+  GIT_CONFIG_COUNT: '1'
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
+jobs:
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: check-${{ github.workflow }}-${{ github.ref }}-codeql-${{ matrix.language }}
+      cancel-in-progress: true
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, actions]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+
+  dependency-review:
+    name: Dependency Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: check-${{ github.workflow }}-${{ github.ref }}-dependency-review
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Review dependency changes
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.gitkeep
+++ b/.gitkeep
@@ -2,3 +2,4 @@
 # .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106
 # Updated: 2026-07-20T11:05:28.272Z
 # Updated: 2026-07-20T11:57:21.324Z
+# Updated: 2026-08-09T00:18:25.927Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -2,4 +2,3 @@
 # .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106
 # Updated: 2026-07-20T11:05:28.272Z
 # Updated: 2026-07-20T11:57:21.324Z
-# Updated: 2026-08-09T00:18:25.927Z

--- a/tests/security-workflow.test.js
+++ b/tests/security-workflow.test.js
@@ -61,7 +61,7 @@ describe('security workflow', () => {
     );
     expect(dependencyReview).toContain('      pull-requests: write');
     expect(dependencyReview).toContain(
-      'uses: actions/dependency-review-action@v4'
+      'uses: actions/dependency-review-action@v5'
     );
     expect(dependencyReview).toContain('          fail-on-severity: high');
     expect(dependencyReview).toContain(

--- a/tests/security-workflow.test.js
+++ b/tests/security-workflow.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'test-anywhere';
+import { existsSync, readFileSync } from 'node:fs';
+
+const workflowPath = '.github/workflows/security.yml';
+const workflow = existsSync(workflowPath)
+  ? readFileSync(workflowPath, 'utf8').replaceAll('\r\n', '\n')
+  : '';
+
+function getJobBlock(jobName) {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex((line) => line === `  ${jobName}:`);
+
+  if (start === -1) {
+    return '';
+  }
+
+  const end = lines.findIndex(
+    (line, index) => index > start && /^ {2}[a-zA-Z0-9_-]+:\s*$/.test(line)
+  );
+
+  return lines.slice(start, end === -1 ? lines.length : end).join('\n');
+}
+
+describe('security workflow', () => {
+  it('runs on main pushes, pull requests, weekly schedules, and manual dispatches', () => {
+    expect(existsSync(workflowPath)).toBe(true);
+    expect(workflow).toContain('  push:\n    branches: [main]');
+    expect(workflow).toContain('  pull_request:');
+    expect(workflow).toContain("    - cron: '0 6 * * 1'");
+    expect(workflow).toContain('  workflow_dispatch:');
+  });
+
+  it('analyzes JavaScript and GitHub Actions with CodeQL', () => {
+    const codeql = getJobBlock('codeql');
+
+    expect(codeql).toContain('    timeout-minutes: 30');
+    expect(codeql).toContain(
+      '      group: check-${{ github.workflow }}-${{ github.ref }}-codeql-${{ matrix.language }}\n      cancel-in-progress: true'
+    );
+    expect(codeql).toContain(
+      '        language: [javascript-typescript, actions]'
+    );
+    expect(codeql).toContain('      actions: read');
+    expect(codeql).toContain('      security-events: write');
+    expect(codeql).toContain('uses: actions/checkout@v6');
+    expect(codeql).toContain('uses: github/codeql-action/init@v4');
+    expect(codeql).toContain('languages: ${{ matrix.language }}');
+    expect(codeql).toContain('uses: github/codeql-action/autobuild@v4');
+    expect(codeql).toContain('uses: github/codeql-action/analyze@v4');
+  });
+
+  it('rejects high-severity dependency changes only on pull requests', () => {
+    const dependencyReview = getJobBlock('dependency-review');
+
+    expect(dependencyReview).toContain(
+      "    if: github.event_name == 'pull_request'"
+    );
+    expect(dependencyReview).toContain('    timeout-minutes: 10');
+    expect(dependencyReview).toContain(
+      '      group: check-${{ github.workflow }}-${{ github.ref }}-dependency-review\n      cancel-in-progress: true'
+    );
+    expect(dependencyReview).toContain('      pull-requests: write');
+    expect(dependencyReview).toContain(
+      'uses: actions/dependency-review-action@v4'
+    );
+    expect(dependencyReview).toContain('          fail-on-severity: high');
+    expect(dependencyReview).toContain(
+      '          comment-summary-in-pr: on-failure'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #122.

This template had no automated security analysis, so vulnerable dependency additions and security flaws in JavaScript or GitHub Actions workflows could pass every existing check.

## Changes

- Add a separate `.github/workflows/security.yml` workflow for pull requests, pushes to `main`, weekly scheduled scans, and manual runs.
- Run CodeQL v4 for both `javascript-typescript` and `actions`.
- Run dependency review v5 on pull requests and fail on newly introduced high or critical vulnerabilities.
- Keep the workflow read-only by default, with narrowly scoped job permissions, explicit timeouts, and cancellable check concurrency.
- Add contract tests covering triggers, languages, action inputs, permissions, timeouts, concurrency, and dependency-review policy.
- Add a patch changeset.
- Enable the repository dependency graph through Dependabot vulnerability alerts so dependency review can execute.

The issue sample used CodeQL v3 and the singular `language` input. Current GitHub documentation and the pinned action metadata use CodeQL v4 and the `languages` input, which this PR follows.

## Reproduction

Against the base branch, `.github/workflows/security.yml` does not exist and the new security workflow test fails all three cases. With this change, the workflow exists and its security contracts pass.

The first CI run also reproduced the repository prerequisite: dependency review failed because the dependency graph was disabled. After enabling it, the dependency-review API returned the expected dependency diff and the corrective CI run passed.

## Testing

- `node --test --test-timeout=30000 tests/security-workflow.test.js` — 3 passed
- `npm test` — 206 passed
- `bun test --timeout 30000` — 206 passed
- `deno test --allow-read` — 175 passed
- `npm run check`
- `bash scripts/check-mjs-syntax.sh`
- `bash scripts/check-file-line-limits.sh`
- `actionlint .github/workflows/*.yml`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`
- GitHub Actions — security workflow, fresh-merge checks, and 3-runtime × 3-OS matrix passed
