### PR TITLE
fix(ci): expose timeout cancellations as failures

### DIFF
--- a/.changeset/loud-timeout-cancellations.md
+++ b/.changeset/loud-timeout-cancellations.md
@@ -1,0 +1,5 @@
+---
+'@link-foundation/example-package-name': patch
+---
+
+Report release pipeline timeout cancellations as visible failures on the default branch.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 5
     concurrency:
       group: check-${{ github.workflow }}-${{ github.ref }}-detect-changes
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     if: github.event_name != 'workflow_dispatch'
     outputs:
       js-changed: ${{ steps.changes.outputs.js-changed }}
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 5
     concurrency:
       group: check-${{ github.workflow }}-${{ github.ref }}-test-compilation
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     needs: [detect-changes]
     if: |
       needs.detect-changes.outputs.js-changed == 'true'
@@ -98,7 +98,7 @@ jobs:
     timeout-minutes: 5
     concurrency:
       group: check-${{ github.workflow }}-${{ github.ref }}-check-file-line-limits
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     needs: [detect-changes]
     if: |
       needs.detect-changes.outputs.docs-changed == 'true' ||
@@ -129,7 +129,7 @@ jobs:
     timeout-minutes: 5
     concurrency:
       group: check-${{ github.workflow }}-${{ github.ref }}-version-check
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v6
@@ -151,7 +151,7 @@ jobs:
     timeout-minutes: 10
     concurrency:
       group: check-${{ github.workflow }}-${{ github.ref }}-changeset-check
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     needs: [detect-changes]
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
     steps:
@@ -199,7 +199,7 @@ jobs:
     timeout-minutes: 10
     concurrency:
       group: check-${{ github.workflow }}-${{ github.ref }}-lint
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     needs: [detect-changes]
     if: |
       !cancelled() &&
@@ -253,7 +253,7 @@ jobs:
     timeout-minutes: 10
     concurrency:
       group: check-${{ github.workflow }}-${{ github.ref }}-test-${{ matrix.runtime }}-${{ matrix.os }}
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     needs:
       [
         detect-changes,
@@ -350,7 +350,7 @@ jobs:
     timeout-minutes: 30
     concurrency:
       group: check-${{ github.workflow }}-${{ github.ref }}-docker-build
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     needs: [detect-changes]
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
     permissions:
@@ -390,7 +390,7 @@ jobs:
     timeout-minutes: 5
     concurrency:
       group: check-${{ github.workflow }}-${{ github.ref }}-validate-docs
-      cancel-in-progress: true
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     needs: [detect-changes]
     if: |
       needs.detect-changes.outputs.docs-changed == 'true'
@@ -727,3 +727,42 @@ jobs:
             2. Merge this PR to main
             3. The automated release workflow will create a version PR
             4. Merge the version PR to publish to npm and create a GitHub release
+
+  # GitHub reports jobs killed by timeout-minutes as cancelled rather than
+  # failed. Observe every job so those cancellations become visible failures
+  # on main, where concurrency never supersedes an in-progress run.
+  pipeline-status:
+    name: Pipeline Status
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: check-${{ github.workflow }}-${{ github.ref }}-pipeline-status
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    if: always()
+    needs:
+      - detect-changes
+      - test-compilation
+      - check-file-line-limits
+      - version-check
+      - changeset-check
+      - lint
+      - test
+      - docker-build
+      - validate-docs
+      - release
+      - instant-release
+      - docker-publish
+      - changeset-pr
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Fail the run when a required job was cancelled or failed
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          IS_MAIN: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+        run: bash scripts/check-pipeline-status.sh

--- a/.gitkeep
+++ b/.gitkeep
@@ -2,4 +2,3 @@
 # .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106
 # Updated: 2026-07-20T11:05:28.272Z
 # Updated: 2026-07-20T11:57:21.324Z
-# Updated: 2026-08-09T00:23:21.703Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -2,3 +2,4 @@
 # .gitkeep file auto-generated at 2026-07-20T10:53:27.981Z for PR creation at branch issue-106-baf7ec38511b for issue https://github.com/link-foundation/js-ai-driven-development-pipeline-template/issues/106
 # Updated: 2026-07-20T11:05:28.272Z
 # Updated: 2026-07-20T11:57:21.324Z
+# Updated: 2026-08-09T00:23:21.703Z

--- a/scripts/check-pipeline-status.sh
+++ b/scripts/check-pipeline-status.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Turn timeout cancellations into visible failures on the release branch.
+set -euo pipefail
+
+: "${NEEDS_JSON:?NEEDS_JSON is required (pass toJSON(needs))}"
+IS_MAIN="${IS_MAIN:-false}"
+
+select_by_result() {
+  NEEDS_JSON="$NEEDS_JSON" WANT_RESULT="$1" node --input-type=module -e '
+    const needs = JSON.parse(process.env.NEEDS_JSON);
+    const jobs = Object.entries(needs)
+      .filter(([, value]) => value.result === process.env.WANT_RESULT)
+      .map(([name]) => name);
+    console.log(jobs.join(", "));
+  '
+}
+
+failed="$(select_by_result failure)"
+cancelled="$(select_by_result cancelled)"
+
+echo "Failed jobs:    ${failed:-<none>}"
+echo "Cancelled jobs: ${cancelled:-<none>}"
+
+status=0
+
+if [ -n "$failed" ]; then
+  echo "::error::Pipeline failed. Failing jobs: ${failed}"
+  status=1
+fi
+
+if [ -n "$cancelled" ]; then
+  if [ "$IS_MAIN" = "true" ]; then
+    echo "::error::Pipeline has cancelled jobs on main: ${cancelled}. A job killed by 'timeout-minutes' is reported as cancelled, which would otherwise hide the failure."
+    status=1
+  else
+    echo "::warning::Cancelled jobs: ${cancelled}. On a non-default ref this is usually a superseded run."
+  fi
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "All required jobs succeeded or were legitimately skipped."
+fi
+
+exit "$status"

--- a/tests/ci-timeouts.test.js
+++ b/tests/ci-timeouts.test.js
@@ -61,6 +61,7 @@ describe('CI timeout policy', () => {
       'docker-build': 30,
       'docker-publish': 30,
       'changeset-pr': 10,
+      'pipeline-status': 5,
     };
 
     expect(listWorkflowJobs(releaseWorkflow).sort()).toEqual(

--- a/tests/pipeline-status.test.js
+++ b/tests/pipeline-status.test.js
@@ -80,6 +80,7 @@ describe('pipeline status gate', () => {
     const gate = getJobBlock(workflow, 'pipeline-status');
 
     expect(gate).toContain('    if: always()');
+    expect(gate).toContain('uses: actions/setup-node@v6');
     expect(gate).toContain('NEEDS_JSON: ${{ toJSON(needs) }}');
     expect(gate).toContain(
       "IS_MAIN: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}"

--- a/tests/pipeline-status.test.js
+++ b/tests/pipeline-status.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'test-anywhere';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, URL } from 'node:url';
+
+const workflow = readFileSync(
+  '.github/workflows/release.yml',
+  'utf8'
+).replaceAll('\r\n', '\n');
+const scriptPath = fileURLToPath(
+  new URL('../scripts/check-pipeline-status.sh', import.meta.url)
+);
+const canRunBash =
+  typeof Deno === 'undefined' &&
+  typeof process !== 'undefined' &&
+  process.platform !== 'win32';
+
+function listWorkflowJobs(source) {
+  const jobsStart = source.indexOf('\njobs:\n');
+  const jobsBody = jobsStart === -1 ? '' : source.slice(jobsStart);
+
+  return Array.from(
+    jobsBody.matchAll(/^[ ]{2}([a-zA-Z0-9_-]+):\s*$/gm),
+    (match) => match[1]
+  );
+}
+
+function getJobBlock(source, jobName) {
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) => line === `  ${jobName}:`);
+
+  if (start === -1) {
+    return '';
+  }
+
+  const end = lines.findIndex(
+    (line, index) => index > start && /^[ ]{2}[a-zA-Z0-9_-]+:\s*$/.test(line)
+  );
+
+  return lines.slice(start, end === -1 ? lines.length : end).join('\n');
+}
+
+function listNeededJobs(jobBlock) {
+  const lines = jobBlock.split('\n');
+  const needsStart = lines.findIndex((line) => line === '    needs:');
+
+  if (needsStart === -1) {
+    return [];
+  }
+
+  const neededJobs = [];
+
+  for (const line of lines.slice(needsStart + 1)) {
+    const item = line.match(/^[ ]{6}- ([a-zA-Z0-9_-]+)\s*$/);
+
+    if (!item) {
+      break;
+    }
+
+    neededJobs.push(item[1]);
+  }
+
+  return neededJobs;
+}
+
+function runGate(needs, isMain = false) {
+  return spawnSync('bash', [scriptPath], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      NEEDS_JSON: JSON.stringify(needs),
+      IS_MAIN: String(isMain),
+    },
+  });
+}
+
+describe('pipeline status gate', () => {
+  it('observes every other release workflow job', () => {
+    const jobs = listWorkflowJobs(workflow);
+    const gate = getJobBlock(workflow, 'pipeline-status');
+
+    expect(gate).toContain('    if: always()');
+    expect(gate).toContain('NEEDS_JSON: ${{ toJSON(needs) }}');
+    expect(gate).toContain(
+      "IS_MAIN: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}"
+    );
+    expect(listNeededJobs(gate).sort()).toEqual(
+      jobs.filter((job) => job !== 'pipeline-status').sort()
+    );
+  });
+
+  it('does not cancel superseded jobs on main', () => {
+    expect(workflow).not.toContain('      cancel-in-progress: true');
+    expect(workflow).toContain(
+      "      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}"
+    );
+  });
+
+  if (canRunBash) {
+    it('passes when jobs succeeded or were skipped', () => {
+      const result = runGate({
+        lint: { result: 'success' },
+        release: { result: 'skipped' },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Failed jobs:    <none>');
+      expect(result.stdout).toContain('Cancelled jobs: <none>');
+    });
+
+    it('fails for a failed job on every ref', () => {
+      const result = runGate({ lint: { result: 'failure' } });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('Pipeline failed. Failing jobs: lint');
+    });
+
+    it('fails for a cancelled job on main', () => {
+      const result = runGate({ release: { result: 'cancelled' } }, true);
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain(
+        'Pipeline has cancelled jobs on main: release'
+      );
+    });
+
+    it('warns for a cancelled job on a non-default ref', () => {
+      const result = runGate({ test: { result: 'cancelled' } });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('::warning::Cancelled jobs: test');
+    });
+  }
+});

--- a/tests/workflow-reliability.test.js
+++ b/tests/workflow-reliability.test.js
@@ -129,10 +129,11 @@ function expectMainWriterConcurrency(jobBlock) {
 function expectCancellableCheckConcurrency(
   jobBlock,
   jobName,
-  matrixSuffix = ''
+  matrixSuffix = '',
+  cancelInProgress = 'true'
 ) {
   expect(jobBlock).toContain(
-    `    concurrency:\n      group: check-\${{ github.workflow }}-\${{ github.ref }}-${jobName}${matrixSuffix}\n      cancel-in-progress: true`
+    `    concurrency:\n      group: check-\${{ github.workflow }}-\${{ github.ref }}-${jobName}${matrixSuffix}\n      cancel-in-progress: ${cancelInProgress}`
   );
 }
 
@@ -229,13 +230,16 @@ describe('workflow concurrency policy', () => {
     ]) {
       expectCancellableCheckConcurrency(
         getJobBlock(releaseWorkflow, jobName),
-        jobName
+        jobName,
+        '',
+        "${{ github.ref != 'refs/heads/main' }}"
       );
     }
     expectCancellableCheckConcurrency(
       getJobBlock(releaseWorkflow, 'test'),
       'test',
-      '-${{ matrix.runtime }}-${{ matrix.os }}'
+      '-${{ matrix.runtime }}-${{ matrix.os }}',
+      "${{ github.ref != 'refs/heads/main' }}"
     );
 
     for (const jobName of ['web-build', 'android-build', 'ios-build']) {


### PR DESCRIPTION
## What

- Add a terminal `pipeline-status` job that runs with `if: always()` and observes every other job in `release.yml`.
- Fail that gate for any failed job and for cancelled jobs on `main`; keep non-default-ref cancellations as warnings.
- Preserve in-progress `main` checks while retaining superseded-run cancellation on other refs.
- Add a patch changeset and regression coverage that prevents the gate dependency list from drifting.

## Why

GitHub Actions reports jobs killed by `timeout-minutes` as `cancelled`, not `failure`. Without an aggregate observer, a timed-out release job can leave the whole run grey and hide a broken release pipeline.

## Reproduction

A workflow job with `timeout-minutes: 1` that runs `sleep 300` concludes `cancelled`. Before this change, `release.yml` had no terminal job that translated that conclusion into a visible failure.

## Testing

- `npm test` — 212 passed after merging the latest `main`
- `npm run check` — lint, Prettier, and duplication checks passed
- GitHub Actions runtime matrix — Node, Bun, and Deno passed on Ubuntu, macOS, and Windows
- GitHub Actions security — CodeQL and dependency review passed
- `bash scripts/check-file-line-limits.sh`
- `bash -n scripts/check-pipeline-status.sh`
- `GITHUB_BASE_REF=main node scripts/validate-changeset.mjs`

Fixes #123
